### PR TITLE
Print zero register as destination for SUBS (immediate).

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -296,6 +296,8 @@ def addCommonOptions(parser):
     parser.add_option("--restore-simpoint-checkpoint", action="store_true",
         help="restore from a simpoint checkpoint taken with " +
              "--take-simpoint-checkpoints")
+    parser.add_option("--enable-simpoint-slicing", action="store_true",
+                     help="Enable saving simpoint checkpoint assembly");
 
     # Checkpointing options
     ###Note that performing checkpointing via python script files will override

--- a/configs/common/Simulation.py
+++ b/configs/common/Simulation.py
@@ -138,19 +138,7 @@ def findCptDir(options, cptdir, testsys):
         fatal("checkpoint dir %s does not exist!", cptdir)
 
     cpt_starttick = 0
-    if options.at_instruction or options.simpoint:
-        inst = options.checkpoint_restore
-        if options.simpoint:
-            # assume workload 0 has the simpoint
-            if testsys.cpu[0].workload[0].simpoint == 0:
-                fatal('Unable to find simpoint')
-            inst += int(testsys.cpu[0].workload[0].simpoint)
-
-        checkpoint_dir = joinpath(cptdir, "cpt.%s.%s" % (options.bench, inst))
-        if not exists(checkpoint_dir):
-            fatal("Unable to find checkpoint directory %s", checkpoint_dir)
-
-    elif options.restore_simpoint_checkpoint:
+    if options.restore_simpoint_checkpoint:
         # Restore from SimPoint checkpoints
         # Assumes that the checkpoint dir names are formatted as follows:
         dirs = listdir(cptdir)
@@ -185,6 +173,18 @@ def findCptDir(options, cptdir, testsys):
         print("Resuming from SimPoint", end=' ')
         print("#%d, start_inst:%d, weight:%f, interval:%d, warmup:%d" %
             (index, start_inst, weight_inst, interval_length, warmup_length))
+
+    elif options.at_instruction or options.simpoint:
+        inst = options.checkpoint_restore
+        if options.simpoint:
+            # assume workload 0 has the simpoint
+            if testsys.cpu[0].workload[0].simpoint == 0:
+                fatal('Unable to find simpoint')
+            inst += int(testsys.cpu[0].workload[0].simpoint)
+
+        checkpoint_dir = joinpath(cptdir, "cpt.%s.%s" % (options.bench, inst))
+        if not exists(checkpoint_dir):
+            fatal("Unable to find checkpoint directory %s", checkpoint_dir)
 
     else:
         dirs = listdir(cptdir)

--- a/src/arch/arm/decoder.hh
+++ b/src/arch/arm/decoder.hh
@@ -208,6 +208,8 @@ class Decoder
     {
         sveLen = len;
     }
+
+    ExtMachInst getInst() const { return emi; };
 };
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/branch.cc
+++ b/src/arch/arm/insts/branch.cc
@@ -56,7 +56,13 @@ std::string
 BranchImm::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -70,6 +76,15 @@ BranchRegReg::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     ccprintf(ss, ", ");
     printIntReg(ss, op2);
     return ss.str();
+}
+
+bool
+BranchImm::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
 }
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/branch.hh
+++ b/src/arch/arm/insts/branch.hh
@@ -59,6 +59,7 @@ class BranchImm : public PredOp
     {}
 
     std::string generateDisassembly(Addr pc, const SymbolTable *symtab) const;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab);
 };
 
 // Conditionally Branch to a target computed with an immediate

--- a/src/arch/arm/insts/branch64.cc
+++ b/src/arch/arm/insts/branch64.cc
@@ -74,7 +74,13 @@ BranchImmCond64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false, true, condCode);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -84,7 +90,13 @@ BranchImm64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -124,9 +136,15 @@ BranchImmReg64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
     printIntReg(ss, op1);
     ccprintf(ss, ", ");
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -136,11 +154,53 @@ BranchImmImmReg64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
     printIntReg(ss, op1);
     ccprintf(ss, ", #%#x, ", imm1);
+    if (symtab && symtab->findLabel(pc + imm2, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm2);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm2, symtab);
     return ss.str();
+}
+
+bool
+BranchImmCond64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
+}
+
+bool
+BranchImm64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
+}
+
+bool
+BranchImmReg64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
+}
+
+bool
+BranchImmImmReg64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm2;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
 }
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/branch64.hh
+++ b/src/arch/arm/insts/branch64.hh
@@ -63,6 +63,7 @@ class BranchImm64 : public ArmStaticInst
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 // Conditionally Branch to a target computed with an immediate
@@ -79,6 +80,7 @@ class BranchImmCond64 : public BranchImm64
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 // Branch to a target computed with a register
@@ -143,6 +145,7 @@ class BranchImmReg64 : public ArmStaticInst
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 // Branch to a target computed with two immediates
@@ -169,6 +172,7 @@ class BranchImmImmReg64 : public ArmStaticInst
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 }

--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -282,7 +282,15 @@ RegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     std::stringstream ss;
     printMnemonic(ss);
     printIntReg(ss, dest);
-    ccprintf(ss, ", #%d, #%d", imm1, imm2);
+    // Print LSL for Move (wide immediate): MOVZ, MOVN and MOVK.
+    std::string str(ss.str());
+    if (str.find("movz") != std::string::npos ||
+            str.find("movn") != std::string::npos ||
+            str.find("movk") != std::string::npos) {
+        ccprintf(ss, ", #%d, LSL #%d", imm1, imm2);
+    } else {
+        ccprintf(ss, ", #%d, #%d", imm1, imm2);
+    }
     return ss.str();
 }
 

--- a/src/arch/arm/insts/static_inst.cc
+++ b/src/arch/arm/insts/static_inst.cc
@@ -303,7 +303,7 @@ ArmStaticInst::printIntReg(std::ostream &os, RegIndex reg_idx,
             ccprintf(os, "ureg0");
         else if (reg_idx == INTREG_SPX)
             ccprintf(os, "%s%s", (opWidth == 32) ? "w" : "", "sp");
-        else if (reg_idx == INTREG_X31)
+        else if (reg_idx == INTREG_X31 || reg_idx == INTREG_ZERO)
             ccprintf(os, "%szr", (opWidth == 32) ? "w" : "x");
         else
             ccprintf(os, "%s%d", (opWidth == 32) ? "w" : "x", reg_idx);
@@ -598,6 +598,16 @@ ArmStaticInst::printDataInst(std::ostream &os, bool withImm,
     if (rd != INTREG_ZERO) {
         firstOp = false;
         printIntReg(os, rd);
+    }
+    if (rd == INTREG_ZERO) { // Print zero register as destination for SUBS (immediate).
+        std::stringstream ss;
+        ss << os.rdbuf();
+        std::string str(ss.str());
+        int pos = str.find("subs");
+        if (pos != std::string::npos) {
+            firstOp = false;
+            printIntReg(os, rd);
+        }
     }
 
     // Source 1.

--- a/src/arch/arm/insts/static_inst.hh
+++ b/src/arch/arm/insts/static_inst.hh
@@ -556,6 +556,46 @@ class ArmStaticInst : public StaticInst
         return getCurSveVecLenInBits(tc) / (8 * sizeof(T));
     }
 };
+
+class ArmStaticInstEncoder : public ArmStaticInst
+{
+  public:
+    ArmStaticInstEncoder(ExtMachInst emi)
+        : ArmStaticInst("asm", emi, No_OpClass)
+    {}
+
+    Fault
+    execute(ExecContext *xc, Trace::InstRecord *traceData) const override
+    {
+        return NoFault;
+    }
+
+    void
+    advancePC(TheISA::PCState &pcState) const override
+    {
+        pcState.advance();
+    }
+
+    std::string
+    generateDisassembly(Addr pc, const SymbolTable *symtab) const override
+    {
+        return mnemonic;
+    }
+
+    void
+    encodeIntReg(std::ostream &os, RegIndex idx, uint8_t opWidth = 64)
+    {
+        printIntReg(os, idx, opWidth);
+    }
+
+    void
+    encodeMiscReg(std::ostream &os, RegIndex idx)
+    {
+        printMiscReg(os, idx);
+    }
+
+  private:
+};
 }
 
 #endif //__ARCH_ARM_INSTS_STATICINST_HH__

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -706,7 +706,29 @@ namespace ArmISA
 
         void startup(ThreadContext *tc);
 
-        Enums::DecoderFlavour decoderFlavour() const { return _decoderFlavour; }
+        // Dump register context
+        uint64_t readMem(BaseCPU *cpu, ThreadContext *tc, Addr addr,
+            bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                              Request::Flags flags));
+        void dumpMem(BaseCPU *cpu, ThreadContext *tc,
+                     Addr addr, uint64_t data);
+        void dumpMem(BaseCPU *cpu, ThreadContext *tc, Addr addr,
+            bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                              Request::Flags flags));
+        void dumpIntReg(BaseCPU *cpu, ThreadContext *tc,
+                        RegIndex idx, RegVal val);
+        void dumpIntReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx);
+        void dumpMiscReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx);
+        void dumpContextRegs(BaseCPU *cpu, ThreadContext *tc,
+            bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                              Request::Flags));
+        // Dump call return instruction
+        void dumpCallReturn(BaseCPU *cpu);
+
+        Enums::DecoderFlavour decoderFlavour() const
+        {
+            return _decoderFlavour;
+        }
 
         /** Getter for haveGICv3CPUInterface */
         bool haveGICv3CpuIfc() const

--- a/src/base/loader/symtab.cc
+++ b/src/base/loader/symtab.cc
@@ -52,6 +52,31 @@ SymbolTable::clear()
 }
 
 bool
+SymbolTable::insert_target(Addr address)
+{
+    ostringstream ostr;
+    string symbol;
+    string target;
+    Addr symAddr;
+
+    if (!findNearestSymbol(address, symbol, symAddr))
+        return false;
+
+    // Avoid adding named branch target (label) for a named symbol.
+    if (address == symAddr)
+        return true;
+
+    // Avoid adding duplicated label.
+    if (findLabel(address, target))
+        return true;
+
+    ostr << symbol << "_" << address - symAddr;
+    targetTable.insert(make_pair(address, ostr.str()));
+
+    return true;
+}
+
+bool
 SymbolTable::insert(Addr address, string symbol)
 {
     if (symbol.empty())

--- a/src/base/loader/symtab.hh
+++ b/src/base/loader/symtab.hh
@@ -48,6 +48,7 @@ class SymbolTable
   private:
     ATable addrTable;
     STable symbolTable;
+    ATable targetTable;
 
   private:
     bool
@@ -70,10 +71,12 @@ class SymbolTable
 
     void clear();
     bool insert(Addr address, std::string symbol);
+    bool insert_target(Addr address);
     bool load(const std::string &file);
 
     const ATable &getAddrTable() const { return addrTable; }
     const STable &getSymbolTable() const { return symbolTable; }
+    const ATable &getTargetTable() const { return targetTable; }
 
   public:
     void serialize(const std::string &base, CheckpointOut &cp) const;
@@ -91,6 +94,30 @@ class SymbolTable
         // address. For simplicity, just return the first one.
         symbol = (*i).second;
         return true;
+    }
+
+    bool
+    findTarget(Addr address, std::string &target) const
+    {
+        ATable::const_iterator i = targetTable.find(address);
+        if (i == targetTable.end())
+            return false;
+
+        target = (*i).second;
+        return true;
+    }
+
+    bool
+    findLabel(Addr address, std::string &label) const
+    {
+        Addr target;
+
+        if (findNearestSymbol(address, label, target) &&
+            target == address)
+            return true;
+
+        // Only works when enableTarget is true.
+        return findTarget(address, label);
     }
 
     bool

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -212,6 +212,8 @@ class BaseCPU(ClockedObject):
         "terminate when any thread reaches this inst count")
     simpoint_start_insts = VectorParam.Counter([],
         "starting instruction counts of simpoints")
+    simpoint_disassembly_path = Param.String("",
+        "Path to save simpoint disassembly")
     max_loads_all_threads = Param.Counter(0,
         "terminate when all threads have reached this load count")
     max_loads_any_thread = Param.Counter(0,

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -131,6 +131,7 @@ BaseCPU::BaseCPU(Params *p, bool is_checker)
       _dataMasterId(p->system->getMasterId(this, "data")),
       _taskId(ContextSwitchTaskId::Unknown), _pid(invldPid),
       _switchedOut(p->switched_out), _cacheLineSize(p->system->cacheLineSize()),
+      _simpointStarted(false),
       interrupts(p->interrupts), profileEvent(NULL),
       numThreads(p->numThreads), system(p->system),
       previousCycle(0), previousState(CPU_STATE_SLEEP),
@@ -179,6 +180,15 @@ BaseCPU::BaseCPU(Params *p, bool is_checker)
         const char *cause = "simpoint starting point found";
         for (size_t i = 0; i < p->simpoint_start_insts.size(); ++i)
             scheduleInstStop(0, p->simpoint_start_insts[i], cause);
+    }
+    // Set up instruction log file stream
+    std::string simpoint_asm_path = p->simpoint_disassembly_path.c_str();
+    if (!simpoint_asm_path.empty()) {
+        simpoint_asm.open(simpoint_asm_path);
+        if (simpoint_asm.is_open()) {
+            std::cout << "Disassembling simpoint to ";
+            std::cout << simpoint_asm_path << "." << std::endl;
+        }
     }
 
     if (p->max_insts_all_threads != 0) {
@@ -275,6 +285,7 @@ BaseCPU::~BaseCPU()
     delete profileEvent;
     delete[] comLoadEventQueue;
     delete[] comInstEventQueue;
+    simpoint_asm.close();
 }
 
 void
@@ -863,4 +874,85 @@ bool
 BaseCPU::waitForRemoteGDB() const
 {
     return params()->wait_for_remote_gdb;
+}
+
+bool
+BaseCPU::markExecuted(Addr address)
+{
+    int size = symbols.size();
+    int i = 0;
+    std::string sym_str;
+    Addr funcStart, funcEnd;
+
+    if (!debugSymbolTable)
+        return false;
+
+    if (!debugSymbolTable->findNearestSymbol(address, sym_str,
+                                             funcStart, funcEnd)) {
+        funcStart = address;
+        funcEnd = address + 1;
+    }
+
+    if (!_simpointStarted) {
+        simpoint_entry = address;
+        dumpSimulatedRegisters();
+        _simpointStarted = true;
+    }
+
+    while (i < size) {
+        if (funcStart == symbols[i])
+            return false;
+
+        if (funcStart < symbols[i] &&
+            (i == 0 || funcStart > symbols[i - 1]))
+            break;
+        i++;
+    };
+    symbols.insert(symbols.begin() + i, funcStart);
+    return true;
+}
+
+bool
+BaseCPU::markBranched(Addr address)
+{
+    int size;
+    int i;
+
+    size = symbols.size();
+    i = 0;
+    while (i < size) {
+        if (address == symbols[i])
+            return false;
+        i++;
+    }
+
+    size = branches.size();
+    i = 0;
+    while (i < size) {
+        if (address == branches[i])
+            return false;
+
+        if (address < branches[i] &&
+            (i == 0 || address > branches[i - 1]))
+            break;
+        i++;
+    };
+    branches.insert(branches.begin() + i, address);
+    return true;
+}
+
+bool
+BaseCPU::markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value)
+{
+    std::string opstr = opcls == MemReadOp ? "R:0x" : "W:0x";
+    std::cout << opstr << std::hex << addr << "=0x";
+    std::cout << std::hex << value << std::endl;
+    return true;
+}
+
+void
+sliceSimPoint()
+{
+    std::cout << "Slicing SimPoint..." << std::endl;
+    BaseCPU::dumpSimulatedInsts();
 }

--- a/src/cpu/exetrace.cc
+++ b/src/cpu/exetrace.cc
@@ -71,7 +71,13 @@ ExeTracerRecord::dumpTicks(ostream &outs)
 void
 Trace::ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
 {
+    BaseCPU *cpu = thread->getCpuPtr();
     ostream &outs = Trace::output();
+    OpClass opcls = inst->opClass();
+
+    if (opcls == MemReadOp || opcls == MemWriteOp) {
+        cpu->markAccessed(opcls, addr, size, data.as_int);
+    }
 
     if (!Debug::ExecUser || !Debug::ExecKernel) {
         bool in_user_mode = TheISA::inUserMode(thread);
@@ -122,7 +128,7 @@ Trace::ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
         outs << " : ";
 
         if (Debug::ExecOpClass) {
-            outs << Enums::OpClassStrings[inst->opClass()] << " : ";
+            outs << Enums::OpClassStrings[opcls] << " : ";
         }
 
         if (Debug::ExecResult && !predicate) {

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -553,9 +553,13 @@ BaseSimpleCPU::preExecute()
     //If we decoded an instruction this "tick", record information about it.
     if (curStaticInst) {
 #if TRACING_ON
-        traceData = tracer->getInstRecord(curTick(), thread->getTC(),
-                curStaticInst, thread->pcState(), curMacroStaticInst);
+        PCState pcState = thread->pcState();
 
+        // Mark the PC related symbol as executed.
+        markExecuted(pcState.instAddr());
+
+        traceData = tracer->getInstRecord(curTick(), thread->getTC(),
+                curStaticInst, pcState, curMacroStaticInst);
         DPRINTF(Decode,"Decode: Decoded %s instruction: %#x\n",
                 curStaticInst->getName(), curStaticInst->machInst);
 #endif // TRACING_ON

--- a/src/cpu/simple/noncaching.cc
+++ b/src/cpu/simple/noncaching.cc
@@ -72,3 +72,133 @@ NonCachingSimpleCPUParams::create()
         fatal("only one workload allowed");
     return new NonCachingSimpleCPU(this);
 }
+
+void
+NonCachingSimpleCPU::dumpSimulatedSymbols()
+{
+    if (!debugSymbolTable || !simpoint_asm.is_open())
+        return;
+
+    if (curThread != 0)
+        fatal("Execution disassembly currently does not support SMT");
+
+    SimpleExecContext &t_info = *threadInfo[curThread];
+    SimpleThread* thread = t_info.thread;
+    TheISA::Decoder *decoder = &(thread->decoder);
+    SymbolTable *symtab = debugSymbolTable;
+
+    int size = symbols.size();
+    int i = 0;
+    std::string sym_str;
+    std::string lab_str;
+    Addr funcStart, funcEnd, addr, target;
+    StaticInstPtr instPtr;
+    std::string disassembly;
+    TheISA::PCState pc;
+    bool doDump;
+
+    while (i < size) {
+        if (!symtab->findNearestSymbol(symbols[i], sym_str,
+                                       funcStart, funcEnd))
+            return;
+        if (funcStart != symbols[i])
+            return;
+        simpoint_asm << std::endl << sym_str << ":" << std::endl;
+        doDump = false;
+
+dumpAgain:
+        addr = funcStart;
+        pc = thread->pcState();
+        pc.set(addr);
+        thread->pcState(pc);
+        t_info.fetchOffset = 0;
+
+        while (addr < funcEnd) {
+            if (doDump && simpoint_entry == addr)
+                simpoint_asm << "simpoint_start:" << std::endl;
+            if (doDump && symtab->findTarget(addr, lab_str))
+                simpoint_asm << lab_str << ":" << std::endl;
+
+            Fault fault = NoFault;
+            ifetch_req->taskId(taskId());
+            setupFetchRequest(ifetch_req);
+            fault = thread->itb->translateAtomic(ifetch_req,
+                                                 thread->getTC(),
+                                                 BaseTLB::Execute);
+            if (fault == NoFault) {
+                Packet ifetch_pkt = Packet(ifetch_req, MemCmd::ReadReq);
+                ifetch_pkt.dataStatic(&inst);
+                sendPacket(icachePort, &ifetch_pkt);
+                gtoh(inst);
+
+                Addr fetchPC = (addr & PCMask) + t_info.fetchOffset;
+                decoder->moreBytes(pc, fetchPC, inst);
+                instPtr = decoder->decode(pc);
+                if (instPtr) {
+                    t_info.stayAtPC = false;
+                    thread->pcState(pc);
+                } else {
+                    fatal("Fetching MicroOP?");
+                    t_info.stayAtPC = true;
+                    t_info.fetchOffset += sizeof(MachInst);
+                }
+
+                if (doDump) {
+                    disassembly = instPtr->disassemble(addr, symtab, true);
+                    simpoint_asm << disassembly << std::endl;
+                } else {
+                    if (instPtr->markTarget(addr, target, symtab) &&
+                        symtab->findNearestSymbol(target, sym_str, addr) &&
+                        addr == target) {
+                        markBranched(target);
+                    }
+                }
+            }
+            if (fault != NoFault || !t_info.stayAtPC)
+                advancePC(fault);
+            pc = thread->pcState();
+            addr = pc.instAddr();
+        }
+        if (!doDump) {
+            doDump = true;
+            goto dumpAgain;
+        }
+        i++;
+    }
+
+    size = branches.size();
+    i = 0;
+    while (i < size) {
+        if (!symtab->findNearestSymbol(branches[i], sym_str,
+                                       funcStart, funcEnd))
+            return;
+        if (funcStart != branches[i])
+            return;
+        if (i == 0)
+            simpoint_asm << std::endl;
+        simpoint_asm << sym_str << ":" << std::endl;
+        i++;
+    }
+    thread->getIsaPtr()->dumpCallReturn(this);
+}
+
+static bool
+readMem(BaseCPU *cpu, Addr addr, uint8_t *data,
+        unsigned size, Request::Flags flags)
+{
+    Fault fault = NoFault;
+
+    fault = static_cast<NonCachingSimpleCPU *>(cpu)->
+        readMem(addr, data, size, flags);
+    return fault == NoFault ? true : false;
+}
+
+void
+NonCachingSimpleCPU::dumpSimulatedRegisters()
+{
+    SimpleExecContext &t_info = *threadInfo[curThread];
+    SimpleThread* thread = t_info.thread;
+
+    std::cout << "Dumping registers..." << std::endl;
+    thread->getIsaPtr()->dumpContextRegs(this, thread, ::readMem);
+}

--- a/src/cpu/simple/noncaching.hh
+++ b/src/cpu/simple/noncaching.hh
@@ -54,6 +54,9 @@ class NonCachingSimpleCPU : public AtomicSimpleCPU
 
     void verifyMemoryMode() const override;
 
+    void dumpSimulatedSymbols();
+    void dumpSimulatedRegisters();
+
   protected:
     Tick sendPacket(MasterPort &port, const PacketPtr &pkt) override;
 };

--- a/src/cpu/static_inst.cc
+++ b/src/cpu/static_inst.cc
@@ -119,9 +119,20 @@ StaticInst::branchTarget(ThreadContext *tc) const
     M5_DUMMY_RETURN;
 }
 
-const string &
-StaticInst::disassemble(Addr pc, const SymbolTable *symtab) const
+bool
+StaticInst::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
 {
+    return false;
+}
+
+const string &
+StaticInst::disassemble(Addr pc, const SymbolTable *symtab,
+                        bool redisasm) const
+{
+    if (cachedDisassembly && redisasm) {
+        delete cachedDisassembly;
+        cachedDisassembly = 0;
+    }
     if (!cachedDisassembly)
         cachedDisassembly = new string(generateDisassembly(pc, symtab));
 

--- a/src/cpu/static_inst.hh
+++ b/src/cpu/static_inst.hh
@@ -324,7 +324,7 @@ class StaticInst : public RefCounted, public StaticInstFlags
      * should not be cached, this function should be overridden directly.
      */
     virtual const std::string &disassemble(Addr pc,
-        const SymbolTable *symtab = 0) const;
+        const SymbolTable *symtab = 0, bool redisasm = false) const;
 
     /**
      * Print a separator separated list of this instruction's set flag
@@ -334,6 +334,13 @@ class StaticInst : public RefCounted, public StaticInstFlags
 
     /// Return name of machine instruction
     std::string getName() { return mnemonic; }
+
+    /**
+     * Can be overridden by the immediate branch instructions, to save
+     * the branch target into the symbol table.
+     */
+    virtual bool
+    markTarget(Addr pc, Addr &Target, SymbolTable *symtab);
 
   protected:
     template<typename T>

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -178,6 +178,9 @@ def simulate(*args, **kwargs):
 
     return _m5.event.simulate(*args, **kwargs)
 
+def sliceSimPoint(*args, **kwargs):
+    return _m5.event.sliceSimPoint(*args, **kwargs)
+
 def drain():
     """Drain the simulator in preparation of a checkpoint or memory mode
     switch.

--- a/src/python/pybind11/event.cc
+++ b/src/python/pybind11/event.cc
@@ -109,6 +109,7 @@ pybind_init_event(py::module &m_native)
     m.def("simulate", &simulate,
           py::arg("ticks") = MaxTick);
     m.def("exitSimLoop", &exitSimLoop);
+    m.def("sliceSimPoint", &sliceSimPoint);
     m.def("getEventQueue", []() { return curEventQueue(); },
           py::return_value_policy::reference);
     m.def("setEventQueue", [](EventQueue *q) { return curEventQueue(q); });

--- a/src/sim/sim_exit.hh
+++ b/src/sim/sim_exit.hh
@@ -56,5 +56,6 @@ void exitSimLoop(const std::string &message, int exit_code = 0,
 /// any normal events which are schedule at the current time.
 void exitSimLoopNow(const std::string &message, int exit_code = 0,
                     Tick repeat = 0, bool serialize = false);
+void sliceSimPoint();
 
 #endif // __SIM_EXIT_HH__

--- a/util/term/term.c
+++ b/util/term/term.c
@@ -168,15 +168,6 @@ readwrite(int nfd)
             perror("Select Error:");
         }
 
-        if (n == 0) {
-            if (read(nfd, buf, 0) < 0)
-                return;
-            continue;
-        }
-
-        if (read(nfd, buf, 0) < 0)
-            return;
-
         if (FD_ISSET(nfd, &read_fds)) {
             if ((n = read(nfd, buf, sizeof(buf))) < 0)
                 return;


### PR DESCRIPTION
Print zero register as destination for SUBS (immediate) instruction. 
Result trace example:
    subs   xzr, x1, #15 
Tested with hello.