### PR TITLE
Fix alias of SUB and SUBS

### DIFF
--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -111,7 +111,10 @@ namespace Aarch64
               case 0x2:
                 return new SubXImm(machInst, rdsp, rnsp, imm);
               case 0x3:
-                return new SubXImmCc(machInst, rdzr, rnsp, imm);
+                if (rdzr == INTREG_ZERO)
+                  return new CmpXImmCc(machInst, rdzr, rnsp, imm);
+                else
+                  return new SubXImmCc(machInst, rdzr, rnsp, imm);
               default:
                 M5_UNREACHABLE;
             }
@@ -1280,7 +1283,12 @@ namespace Aarch64
                   case 0x2:
                     return new SubXSReg(machInst, rdzr, rn, rm, imm6, type);
                   case 0x3:
-                    return new SubXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                    if (rdzr == INTREG_ZERO)
+                      return new
+                          CmpXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                    else
+                      return new
+                          SubXSRegCc(machInst, rdzr, rn, rm, imm6, type);
                   default:
                     M5_UNREACHABLE;
                 }
@@ -1305,7 +1313,12 @@ namespace Aarch64
                   case 0x2:
                     return new SubXEReg(machInst, rdsp, rnsp, rm, type, imm3);
                   case 0x3:
-                    return new SubXERegCc(machInst, rdzr, rnsp, rm, type, imm3);
+                    if (rdzr == INTREG_ZERO)
+                      return new
+                          CmpXERegCc(machInst, rdzr, rnsp, rm, type, imm3);
+                    else
+                      return new
+                          SubXERegCc(machInst, rdzr, rnsp, rm, type, imm3);
                   default:
                     M5_UNREACHABLE;
                 }

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -1274,6 +1274,7 @@ namespace Aarch64
                 IntRegIndex rd = (IntRegIndex)(uint8_t)bits(machInst, 4, 0);
                 IntRegIndex rdzr = makeZero(rd);
                 IntRegIndex rn = (IntRegIndex)(uint8_t)bits(machInst, 9, 5);
+                IntRegIndex rnzr = makeZero(rn);
                 IntRegIndex rm = (IntRegIndex)(uint8_t)bits(machInst, 20, 16);
                 switch (switchVal) {
                   case 0x0:
@@ -1281,11 +1282,19 @@ namespace Aarch64
                   case 0x1:
                     return new AddXSRegCc(machInst, rdzr, rn, rm, imm6, type);
                   case 0x2:
-                    return new SubXSReg(machInst, rdzr, rn, rm, imm6, type);
+                    if (rnzr == INTREG_ZERO)
+                      return new
+                          NegXSReg(machInst, rd, rnzr, rm, imm6, type);
+                    else
+                      return new
+                          SubXSReg(machInst, rdzr, rn, rm, imm6, type);
                   case 0x3:
                     if (rdzr == INTREG_ZERO)
                       return new
                           CmpXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                    else if (rnzr == INTREG_ZERO)
+                      return new
+                          NegXSRegCc(machInst, rd, rnzr, rm, imm6, type);
                     else
                       return new
                           SubXSRegCc(machInst, rdzr, rn, rm, imm6, type);

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -99,7 +99,10 @@ let {{
         ccCode = createCcCode64(carryCode64[flagType], overflowCode64[flagType])
         Name = mnem.capitalize() + suffix
         iop = InstObjParams(mnem, Name, base, code)
-        iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
+        if (mnem == "cmp"):
+            iopCc = InstObjParams(mnem, Name + "Cc", base, code + ccCode)
+        else:
+            iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
 
         def subst(iop):
             global header_output, decoder_output, exec_output
@@ -142,6 +145,7 @@ let {{
     buildDataInst("and", "Dest64 = resTemp = Op164 & secOp;")
     buildDataInst("eor", "Dest64 = Op164 ^ secOp;", buildCc = False)
     buildXSRegDataInst("eon", "Dest64 = Op164 ^ ~secOp;", buildCc = False)
+    buildDataInst("cmp", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("sub", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("add", "Dest64 = resTemp = Op164 + secOp;", "add")
     buildXSRegDataInst("adc",

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -146,6 +146,7 @@ let {{
     buildDataInst("eor", "Dest64 = Op164 ^ secOp;", buildCc = False)
     buildXSRegDataInst("eon", "Dest64 = Op164 ^ ~secOp;", buildCc = False)
     buildDataInst("cmp", "Dest64 = resTemp = Op164 - secOp;", "sub")
+    buildDataInst("neg", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("sub", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("add", "Dest64 = resTemp = Op164 + secOp;", "add")
     buildXSRegDataInst("adc",


### PR DESCRIPTION
Add CMP as alias of SUBS (immediate, shifted register and  extended register) when Rd = '11111'
Add NEG(S) as alias of SUB(S) (shifted register) when Rn = '11111'