### PR TITLE
Fix disasmbly of ADRP, LDRx and STRx

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -296,6 +296,8 @@ def addCommonOptions(parser):
     parser.add_option("--restore-simpoint-checkpoint", action="store_true",
         help="restore from a simpoint checkpoint taken with " +
              "--take-simpoint-checkpoints")
+    parser.add_option("--enable-simpoint-slicing", action="store_true",
+                     help="Enable saving simpoint checkpoint assembly");
 
     # Checkpointing options
     ###Note that performing checkpointing via python script files will override

--- a/configs/common/Simulation.py
+++ b/configs/common/Simulation.py
@@ -138,19 +138,7 @@ def findCptDir(options, cptdir, testsys):
         fatal("checkpoint dir %s does not exist!", cptdir)
 
     cpt_starttick = 0
-    if options.at_instruction or options.simpoint:
-        inst = options.checkpoint_restore
-        if options.simpoint:
-            # assume workload 0 has the simpoint
-            if testsys.cpu[0].workload[0].simpoint == 0:
-                fatal('Unable to find simpoint')
-            inst += int(testsys.cpu[0].workload[0].simpoint)
-
-        checkpoint_dir = joinpath(cptdir, "cpt.%s.%s" % (options.bench, inst))
-        if not exists(checkpoint_dir):
-            fatal("Unable to find checkpoint directory %s", checkpoint_dir)
-
-    elif options.restore_simpoint_checkpoint:
+    if options.restore_simpoint_checkpoint:
         # Restore from SimPoint checkpoints
         # Assumes that the checkpoint dir names are formatted as follows:
         dirs = listdir(cptdir)
@@ -185,6 +173,18 @@ def findCptDir(options, cptdir, testsys):
         print("Resuming from SimPoint", end=' ')
         print("#%d, start_inst:%d, weight:%f, interval:%d, warmup:%d" %
             (index, start_inst, weight_inst, interval_length, warmup_length))
+
+    elif options.at_instruction or options.simpoint:
+        inst = options.checkpoint_restore
+        if options.simpoint:
+            # assume workload 0 has the simpoint
+            if testsys.cpu[0].workload[0].simpoint == 0:
+                fatal('Unable to find simpoint')
+            inst += int(testsys.cpu[0].workload[0].simpoint)
+
+        checkpoint_dir = joinpath(cptdir, "cpt.%s.%s" % (options.bench, inst))
+        if not exists(checkpoint_dir):
+            fatal("Unable to find checkpoint directory %s", checkpoint_dir)
 
     else:
         dirs = listdir(cptdir)

--- a/src/arch/arm/decoder.hh
+++ b/src/arch/arm/decoder.hh
@@ -208,6 +208,8 @@ class Decoder
     {
         sveLen = len;
     }
+
+    ExtMachInst getInst() const { return emi; };
 };
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/branch.cc
+++ b/src/arch/arm/insts/branch.cc
@@ -56,7 +56,13 @@ std::string
 BranchImm::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -70,6 +76,15 @@ BranchRegReg::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     ccprintf(ss, ", ");
     printIntReg(ss, op2);
     return ss.str();
+}
+
+bool
+BranchImm::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
 }
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/branch.hh
+++ b/src/arch/arm/insts/branch.hh
@@ -59,6 +59,7 @@ class BranchImm : public PredOp
     {}
 
     std::string generateDisassembly(Addr pc, const SymbolTable *symtab) const;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab);
 };
 
 // Conditionally Branch to a target computed with an immediate

--- a/src/arch/arm/insts/branch64.cc
+++ b/src/arch/arm/insts/branch64.cc
@@ -74,7 +74,13 @@ BranchImmCond64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false, true, condCode);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -84,7 +90,13 @@ BranchImm64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -124,9 +136,15 @@ BranchImmReg64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
     printIntReg(ss, op1);
     ccprintf(ss, ", ");
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm, symtab);
     return ss.str();
 }
@@ -136,11 +154,53 @@ BranchImmImmReg64::generateDisassembly(
         Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     printMnemonic(ss, "", false);
     printIntReg(ss, op1);
     ccprintf(ss, ", #%#x, ", imm1);
+    if (symtab && symtab->findLabel(pc + imm2, label))
+        ccprintf(ss, "%s", label);
+    else
+        ccprintf(ss, "#%d", imm2);
+    ccprintf(ss, "\t// ");
     printTarget(ss, pc + imm2, symtab);
     return ss.str();
+}
+
+bool
+BranchImmCond64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
+}
+
+bool
+BranchImm64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
+}
+
+bool
+BranchImmReg64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
+}
+
+bool
+BranchImmImmReg64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm2;
+    if (symtab)
+        symtab->insert_target(target);
+    return true;
 }
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/branch64.hh
+++ b/src/arch/arm/insts/branch64.hh
@@ -63,6 +63,7 @@ class BranchImm64 : public ArmStaticInst
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 // Conditionally Branch to a target computed with an immediate
@@ -79,6 +80,7 @@ class BranchImmCond64 : public BranchImm64
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 // Branch to a target computed with a register
@@ -143,6 +145,7 @@ class BranchImmReg64 : public ArmStaticInst
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 // Branch to a target computed with two immediates
@@ -169,6 +172,7 @@ class BranchImmImmReg64 : public ArmStaticInst
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab) override;
 };
 
 }

--- a/src/arch/arm/insts/data64.cc
+++ b/src/arch/arm/insts/data64.cc
@@ -52,6 +52,28 @@ DataXImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 }
 
 std::string
+AdrpDataXImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    Addr target = pc + imm;
+    Addr symbolAddr;
+    std::string symbol;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    if (symtab && symtab->findNearestSymbol(target, symbol, symbolAddr)) {
+        ccprintf(ss, ", %s", symbol);
+        if (symbolAddr < target) {
+            ccprintf(ss, "+0x%x", target - symbolAddr);
+        } else if (symbolAddr > target) {
+            ccprintf(ss, "-0x%x", symbolAddr - target);
+        }
+    } else {
+       ccprintf(ss, ", <undefined symbol for address #0x%x>", target);
+    }
+    return ss.str();
+}
+
+std::string
 DataXImmOnlyOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;

--- a/src/arch/arm/insts/data64.hh
+++ b/src/arch/arm/insts/data64.hh
@@ -61,6 +61,22 @@ class DataXImmOp : public ArmStaticInst
             Addr pc, const SymbolTable *symtab) const override;
 };
 
+class AdrpDataXImmOp : public ArmStaticInst
+{
+  protected:
+    IntRegIndex dest, op1;
+    uint64_t imm;
+
+    AdrpDataXImmOp(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
+               IntRegIndex _dest, IntRegIndex _op1, uint64_t _imm) :
+        ArmStaticInst(mnem, _machInst, __opClass),
+        dest(_dest), op1(_op1), imm(_imm)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
 class DataXImmOnlyOp : public ArmStaticInst
 {
   protected:

--- a/src/arch/arm/insts/macromem.hh
+++ b/src/arch/arm/insts/macromem.hh
@@ -440,6 +440,10 @@ class MacroMemOp : public PredMacroOp
 class PairMemOp : public PredMacroOp
 {
   public:
+    RegIndex _rn, _rt, _rt2;
+    bool _writeback,_post;
+    int32_t _imm;
+    uint32_t _size;
     enum AddrMode {
         AddrMd_Offset,
         AddrMd_PreIndex,
@@ -451,6 +455,9 @@ class PairMemOp : public PredMacroOp
               uint32_t size, bool fp, bool load, bool noAlloc, bool signExt,
               bool exclusive, bool acrel, int64_t imm, AddrMode mode,
               IntRegIndex rn, IntRegIndex rt, IntRegIndex rt2);
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
 };
 
 class BigFpMemImmOp : public PredMacroOp

--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -148,7 +148,8 @@ MemoryPostIndex64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     startDisassembly(ss);
     if (imm)
         ccprintf(ss, "], #%d", imm);
-    ccprintf(ss, "]");
+    else
+        ccprintf(ss, "]");
     return ss.str();
 }
 

--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -70,7 +70,7 @@ Memory64::startDisassembly(std::ostream &os) const
         printIntReg(os, dest);
     }
     ccprintf(os, ", [");
-    printIntReg(os, base);
+    printIntReg(os, base, 64); // Rn width is fixed to 64 for LDRx/STRx
 }
 
 void

--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -287,6 +287,16 @@ RegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 }
 
 std::string
+MovxRegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    ccprintf(ss, ", #%d, LSL #%d", imm1, imm2);
+    return ss.str();
+}
+
+std::string
 RegRegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;

--- a/src/arch/arm/insts/misc.hh
+++ b/src/arch/arm/insts/misc.hh
@@ -322,6 +322,19 @@ class RegImmImmOp : public PredOp
             Addr pc, const SymbolTable *symtab) const override;
 };
 
+class MovxRegImmImmOp : public RegImmImmOp
+{
+  protected:
+
+    MovxRegImmImmOp(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
+                IntRegIndex _dest, uint64_t _imm1, uint64_t _imm2) :
+        RegImmImmOp(mnem, _machInst, __opClass, _dest, _imm1, _imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
 class RegRegImmImmOp : public PredOp
 {
   protected:

--- a/src/arch/arm/insts/static_inst.hh
+++ b/src/arch/arm/insts/static_inst.hh
@@ -556,6 +556,46 @@ class ArmStaticInst : public StaticInst
         return getCurSveVecLenInBits(tc) / (8 * sizeof(T));
     }
 };
+
+class ArmStaticInstEncoder : public ArmStaticInst
+{
+  public:
+    ArmStaticInstEncoder(ExtMachInst emi)
+        : ArmStaticInst("asm", emi, No_OpClass)
+    {}
+
+    Fault
+    execute(ExecContext *xc, Trace::InstRecord *traceData) const override
+    {
+        return NoFault;
+    }
+
+    void
+    advancePC(TheISA::PCState &pcState) const override
+    {
+        pcState.advance();
+    }
+
+    std::string
+    generateDisassembly(Addr pc, const SymbolTable *symtab) const override
+    {
+        return mnemonic;
+    }
+
+    void
+    encodeIntReg(std::ostream &os, RegIndex idx, uint8_t opWidth = 64)
+    {
+        printIntReg(os, idx, opWidth);
+    }
+
+    void
+    encodeMiscReg(std::ostream &os, RegIndex idx)
+    {
+        printMiscReg(os, idx);
+    }
+
+  private:
+};
 }
 
 #endif //__ARCH_ARM_INSTS_STATICINST_HH__

--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -38,6 +38,7 @@
  *          Ali Saidi
  */
 
+#include "arch/arm/insts/static_inst.hh"
 #include "arch/arm/isa.hh"
 #include "arch/arm/pmu.hh"
 #include "arch/arm/system.hh"
@@ -2132,6 +2133,233 @@ ISA::zeroSveVecRegUpperPart(VecRegContainer &vc, unsigned eCount)
     for (int i = 2; i < eCount; ++i) {
         vv[i] = 0;
     }
+}
+
+void
+ISA::dumpIntReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx, RegVal val)
+{
+    ExtMachInst emi = 0;
+    emi.aarch64 = true;
+    ArmStaticInstEncoder encoder(emi);
+
+    cpu->simpoint_asm << "  mov   ";
+    encoder.encodeIntReg(cpu->simpoint_asm, idx);
+    cpu->simpoint_asm << ", ";
+    cpu->simpoint_asm << "#0x" <<  std::hex << val << std::dec;
+    cpu->simpoint_asm << std::endl;
+}
+
+void
+ISA::dumpIntReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx)
+{
+    dumpIntReg(cpu, tc, idx, tc->readIntReg(idx));
+}
+
+void
+ISA::dumpMiscReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx)
+{
+    ExtMachInst emi = 0;
+    emi.aarch64 = true;
+    ArmStaticInstEncoder encoder(emi);
+
+    cpu->simpoint_asm << "  mov   x29, ";
+    cpu->simpoint_asm << "#0x" << std::hex << readMiscReg(idx, tc) << std::dec;
+    cpu->simpoint_asm << std::endl;
+    cpu->simpoint_asm << "  msr   ";
+    encoder.encodeMiscReg(cpu->simpoint_asm, idx);
+    cpu->simpoint_asm << ", x29" << std::endl;
+}
+
+uint64_t
+ISA::readMem(BaseCPU *cpu, ThreadContext *tc, Addr addr,
+    bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                      Request::Flags flags))
+{
+    uint64_t val;
+    Request::Flags flags = ArmISA::TLB::AllowUnaligned |
+                           ArmISA::TLB::MustBeOne;
+
+    __readMem(cpu, addr, (uint8_t *)(&val), sizeof(uint64_t), flags);
+    return val;
+}
+
+void
+ISA::dumpFP(BaseCPU *cpu, ThreadContext *tc, int offset)
+{
+    cpu->simpoint_asm << "  add   x29, sp, #" << offset << std::endl;
+}
+
+void
+ISA::dumpLR(BaseCPU *cpu, ThreadContext *tc, Addr lr)
+{
+    std::string sym_str;
+    Addr addr;
+    SymbolTable *symtab = debugSymbolTable;
+
+    if (symtab) {
+        symtab->insert_target(lr);
+        if (symtab->findNearestSymbol(lr, sym_str, addr))
+            cpu->markExecuted(addr);
+        if (symtab->findLabel(lr, sym_str))
+            cpu->simpoint_asm << "  adr   x30, " << sym_str << std::endl;
+        else
+            cpu->simpoint_asm << "  mov   x30, " << lr << std::endl;
+    }
+}
+
+void
+ISA::dumpStackedFP(BaseCPU *cpu, ThreadContext *tc, int offset)
+{
+    cpu->simpoint_asm << "  add   x29, sp, #" << offset << std::endl;
+    cpu->simpoint_asm << "  str   x29, [sp, #8]" << std::endl;
+}
+
+void
+ISA::dumpStackedLR(BaseCPU *cpu, ThreadContext *tc, Addr lr)
+{
+    std::string sym_str;
+    Addr addr;
+    SymbolTable *symtab = debugSymbolTable;
+
+    if (symtab) {
+        symtab->insert_target(lr);
+        if (symtab->findNearestSymbol(lr, sym_str, addr))
+            cpu->markExecuted(addr);
+        if (symtab->findLabel(lr, sym_str))
+            cpu->simpoint_asm << "  adr   x29, " << sym_str << std::endl;
+        else
+            cpu->simpoint_asm << "  mov   x29, " << lr << std::endl;
+        cpu->simpoint_asm << "  str   x29, [sp, #8]" << std::endl;
+    }
+}
+
+void
+ISA::dumpStacked(BaseCPU *cpu, ThreadContext *tc, uint64_t data)
+{
+    cpu->simpoint_asm << "  mov   x29, ";
+    cpu->simpoint_asm << "#0x" << std::hex << data << std::dec;
+    cpu->simpoint_asm << std::endl;
+    cpu->simpoint_asm << "  str   x29, [sp, #8]" << std::endl;
+}
+
+void
+ISA::dumpContextRegs(BaseCPU *cpu, ThreadContext *tc,
+    bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                      Request::Flags flags))
+{
+    uint64_t sp, fp, lr, spBottom, spTop, fpLast, lrLast, ptr;
+    uint64_t fpVal, lrVal, val;
+    int i, stack_depth;
+    std::stack<uint64_t> ss;
+    std::stack<int> fp_idx_queue;
+    std::stack<int> lr_idx_queue;
+
+    if (cpu->simpoint_asm.is_open()) {
+        cpu->simpoint_asm << "simpoint_entry:" << std::endl;
+        // Save special registers, PC is not saved as the dumped symbols
+        // will be linked into the new binary that is executed using the
+        // new link addresses.
+        fpLast = fp = tc->readIntReg(INTREG_X29);
+        lrLast = lr = tc->readIntReg(INTREG_X30);
+        // Only user programs are simulated.
+        spBottom = sp = tc->readIntReg(INTREG_SP0);
+        for (i = 0; i < 29; i++)
+            dumpIntReg(cpu, tc, INTREG_X0 + i);
+        dumpMiscReg(cpu, tc, MISCREG_CPSR);
+        // Dump stack:
+        //      +----------------+
+        //      | LR             |
+        //      +----------------+
+        //      | FP             |
+        // -FP->+----------------+
+        //      | Dynamic Alloc  |
+        //      +----------------+
+        //      | Stack Arg Area |
+        // -SP->+----------------+
+        //      | ...            |
+        //      +----------------+
+        //      | Callee Saved   |
+        //      +----------------+
+        //      | Local Vars     |
+        //      +----------------+
+        //      | LR             |
+        //      +----------------+
+        //      | FP             |
+        // -FP->+----------------+
+        //      | Dynamic Alloc  |
+        //      +----------------+
+        //      | Stack Arg Area |
+        // -SP->+----------------+
+        i = 0;
+        while (fp != 0) {
+            ptr = sp;
+            while (ptr < fp) {
+                val = readMem(cpu, tc, (Addr)ptr, __readMem);
+                ss.push(val);
+                std::cout << "Stack:";
+                std::cout << "0x" << std::hex << ptr << std::dec;
+                std::cout << ":";
+                std::cout << "0x" << std::hex << val << std::dec;
+                std::cout << std::endl;
+                ptr += 8;
+                i += 8;
+            }
+            fp_idx_queue.push(i);
+            fpVal = readMem(cpu, tc, (Addr)fp, __readMem);
+            ss.push(fpVal);
+            i += 8;
+            std::cout << "FP:";
+            std::cout << "0x" << std::hex << fp << std::dec;
+            std::cout << ":";
+            std::cout << "0x" << std::hex << fpVal << std::dec;
+            std::cout << std::endl;
+            lr_idx_queue.push(i);
+            lrVal = readMem(cpu, tc, (Addr)(fp + 8), __readMem);
+            ss.push(lrVal);
+            i += 8;
+            std::cout << "LR:";
+            std::cout << "0x" << std::hex << fp + 8 << std::dec;
+            std::cout << ":";
+            std::cout << "0x" << std::hex << lrVal << std::dec;
+            std::cout << std::endl;
+            sp = fp + 16;
+            fp = fpVal;
+            lr = lrVal;
+        }
+        stack_depth = i;
+        spTop = spBottom + stack_depth;
+
+        // Dump stack context
+        i = 0;
+        while (!ss.empty()) {
+            if (fp_idx_queue.top() == stack_depth - i - 8) {
+                dumpStackedFP(cpu, tc, i + 8 + ss.top() - spTop);
+                fp_idx_queue.pop();
+            } else if (lr_idx_queue.top() == stack_depth - i - 8) {
+                dumpStackedLR(cpu, tc, ss.top());
+                lr_idx_queue.pop();
+            } else {
+                dumpStacked(cpu, tc, ss.top());
+            }
+            ss.pop();
+            i += 8;
+        }
+        // Restore altered special registers.
+        tc->setIntReg(INTREG_X29, fpLast);
+        tc->setIntReg(INTREG_X30, lrLast);
+        tc->setIntReg(INTREG_SP0, spBottom);
+        // Dump altered special registers.
+        dumpFP(cpu, tc, i + 8 + fpLast - spTop);
+        dumpLR(cpu, tc, lrLast);
+        cpu->simpoint_asm << "  b     simpoint_start" << std::endl;
+    }
+}
+
+void
+ISA::dumpCallReturn(BaseCPU *cpu)
+{
+    if (cpu->simpoint_asm.is_open())
+        cpu->simpoint_asm << "  ret" << std::endl;
 }
 
 }  // namespace ArmISA

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -706,7 +706,29 @@ namespace ArmISA
 
         void startup(ThreadContext *tc);
 
-        Enums::DecoderFlavour decoderFlavour() const { return _decoderFlavour; }
+        // Dump register context
+        uint64_t readMem(BaseCPU *cpu, ThreadContext *tc, Addr addr,
+            bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                              Request::Flags flags));
+        void dumpLR(BaseCPU *cpu, ThreadContext *tc, Addr lr);
+        void dumpFP(BaseCPU *cpu, ThreadContext *tc, int offset);
+        void dumpStackedFP(BaseCPU *cpu, ThreadContext *tc, int sp);
+        void dumpStackedLR(BaseCPU *cpu, ThreadContext *tc, Addr lr);
+        void dumpStacked(BaseCPU *cpu, ThreadContext *tc, uint64_t data);
+        void dumpIntReg(BaseCPU *cpu, ThreadContext *tc,
+                        RegIndex idx, RegVal val);
+        void dumpIntReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx);
+        void dumpMiscReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx);
+        void dumpContextRegs(BaseCPU *cpu, ThreadContext *tc,
+            bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
+                              Request::Flags));
+        // Dump call return instruction
+        void dumpCallReturn(BaseCPU *cpu);
+
+        Enums::DecoderFlavour decoderFlavour() const
+        {
+            return _decoderFlavour;
+        }
 
         /** Getter for haveGICv3CPUInterface */
         bool haveGICv3CpuIfc() const

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -107,6 +107,10 @@ namespace ArmISA
 
         bool afterStartup;
 
+        /** Simpoint saved */
+        uint64_t saved_lr;
+        int saved_fp;
+
         /** MiscReg metadata **/
         struct MiscRegLUTEntry {
             uint32_t lower;  // Lower half mapped to this register
@@ -719,9 +723,12 @@ namespace ArmISA
                         RegIndex idx, RegVal val);
         void dumpIntReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx);
         void dumpMiscReg(BaseCPU *cpu, ThreadContext *tc, RegIndex idx);
-        void dumpContextRegs(BaseCPU *cpu, ThreadContext *tc,
+        void dumpContextRegsEarly(BaseCPU *cpu, ThreadContext *tc,
             bool (*__readMem)(BaseCPU *cpu, Addr, uint8_t *, unsigned,
                               Request::Flags));
+        void dumpContextMems(BaseCPU *cpu, ThreadContext *tc,
+                             Addr addr, Addr size, uint64_t value);
+        void dumpContextRegsLate(BaseCPU *cpu, ThreadContext *tc);
         // Dump call return instruction
         void dumpCallReturn(BaseCPU *cpu);
 

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -111,7 +111,10 @@ namespace Aarch64
               case 0x2:
                 return new SubXImm(machInst, rdsp, rnsp, imm);
               case 0x3:
-                return new SubXImmCc(machInst, rdzr, rnsp, imm);
+                if (rdzr == INTREG_ZERO)
+                  return new CmpXImmCc(machInst, rdzr, rnsp, imm);
+                else
+                  return new SubXImmCc(machInst, rdzr, rnsp, imm);
               default:
                 M5_UNREACHABLE;
             }
@@ -1280,7 +1283,12 @@ namespace Aarch64
                   case 0x2:
                     return new SubXSReg(machInst, rdzr, rn, rm, imm6, type);
                   case 0x3:
-                    return new SubXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                    if (rdzr == INTREG_ZERO)
+                      return new
+                          CmpXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                    else
+                      return new
+                          SubXSRegCc(machInst, rdzr, rn, rm, imm6, type);
                   default:
                     M5_UNREACHABLE;
                 }
@@ -1305,7 +1313,12 @@ namespace Aarch64
                   case 0x2:
                     return new SubXEReg(machInst, rdsp, rnsp, rm, type, imm3);
                   case 0x3:
-                    return new SubXERegCc(machInst, rdzr, rnsp, rm, type, imm3);
+                    if (rdzr == INTREG_ZERO)
+                      return new
+                          CmpXERegCc(machInst, rdzr, rnsp, rm, type, imm3);
+                    else
+                      return new
+                          SubXERegCc(machInst, rdzr, rnsp, rm, type, imm3);
                   default:
                     M5_UNREACHABLE;
                 }

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -1274,6 +1274,7 @@ namespace Aarch64
                 IntRegIndex rd = (IntRegIndex)(uint8_t)bits(machInst, 4, 0);
                 IntRegIndex rdzr = makeZero(rd);
                 IntRegIndex rn = (IntRegIndex)(uint8_t)bits(machInst, 9, 5);
+                IntRegIndex rnzr = makeZero(rn);
                 IntRegIndex rm = (IntRegIndex)(uint8_t)bits(machInst, 20, 16);
                 switch (switchVal) {
                   case 0x0:
@@ -1281,11 +1282,19 @@ namespace Aarch64
                   case 0x1:
                     return new AddXSRegCc(machInst, rdzr, rn, rm, imm6, type);
                   case 0x2:
-                    return new SubXSReg(machInst, rdzr, rn, rm, imm6, type);
+                    if (rnzr == INTREG_ZERO)
+                      return new
+                          NegXSReg(machInst, rd, rnzr, rm, imm6, type);
+                    else
+                      return new
+                          SubXSReg(machInst, rdzr, rn, rm, imm6, type);
                   case 0x3:
                     if (rdzr == INTREG_ZERO)
                       return new
                           CmpXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                    else if (rnzr == INTREG_ZERO)
+                      return new
+                          NegXSRegCc(machInst, rd, rnzr, rm, imm6, type);
                     else
                       return new
                           SubXSRegCc(machInst, rdzr, rn, rm, imm6, type);

--- a/src/arch/arm/isa/insts/aarch64.isa
+++ b/src/arch/arm/isa/insts/aarch64.isa
@@ -39,19 +39,19 @@
 
 let {{
     movzCode = 'Dest64 = ((uint64_t)imm1) << imm2;'
-    movzIop = InstObjParams("movz", "Movz", "RegImmImmOp", movzCode, [])
+    movzIop = InstObjParams("movz", "Movz", "MovxRegImmImmOp", movzCode, [])
     header_output += RegImmImmOpDeclare.subst(movzIop)
     decoder_output += RegImmImmOpConstructor.subst(movzIop)
     exec_output += BasicExecute.subst(movzIop)
 
     movkCode = 'Dest64 = insertBits(Dest64, imm2 + 15, imm2, imm1);'
-    movkIop = InstObjParams("movk", "Movk", "RegImmImmOp", movkCode, [])
+    movkIop = InstObjParams("movk", "Movk", "MovxRegImmImmOp", movkCode, [])
     header_output += RegImmImmOpDeclare.subst(movkIop)
     decoder_output += RegImmImmOpConstructor.subst(movkIop)
     exec_output += BasicExecute.subst(movkIop)
 
     movnCode = 'Dest64 = ~(((uint64_t)imm1) << imm2);'
-    movnIop = InstObjParams("movn", "Movn", "RegImmImmOp", movnCode, [])
+    movnIop = InstObjParams("movn", "Movn", "MovxRegImmImmOp", movnCode, [])
     header_output += RegImmImmOpDeclare.subst(movnIop)
     decoder_output += RegImmImmOpConstructor.subst(movnIop)
     exec_output += BasicExecute.subst(movnIop)

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -99,7 +99,10 @@ let {{
         ccCode = createCcCode64(carryCode64[flagType], overflowCode64[flagType])
         Name = mnem.capitalize() + suffix
         iop = InstObjParams(mnem, Name, base, code)
-        iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
+        if (mnem == "cmp"):
+            iopCc = InstObjParams(mnem, Name + "Cc", base, code + ccCode)
+        else:
+            iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
 
         def subst(iop):
             global header_output, decoder_output, exec_output
@@ -142,6 +145,7 @@ let {{
     buildDataInst("and", "Dest64 = resTemp = Op164 & secOp;")
     buildDataInst("eor", "Dest64 = Op164 ^ secOp;", buildCc = False)
     buildXSRegDataInst("eon", "Dest64 = Op164 ^ ~secOp;", buildCc = False)
+    buildDataInst("cmp", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("sub", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("add", "Dest64 = resTemp = Op164 + secOp;", "add")
     buildXSRegDataInst("adc",

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -118,7 +118,11 @@ let {{
     def buildXImmDataInst(mnem, code, flagType = "logic", \
                           buildCc = True, buildNonCc = True, \
                           suffix = "XImm"):
-        buildDataWork(mnem, immOp2 + code, flagType, suffix,
+        if (mnem == "adrp"):
+            buildDataWork(mnem, immOp2 + code, flagType, suffix,
+                      buildCc, buildNonCc, "AdrpDataXImmOp", "DataXImm")
+        else:
+            buildDataWork(mnem, immOp2 + code, flagType, suffix,
                       buildCc, buildNonCc, "DataXImmOp", "DataXImm")
 
     def buildXSRegDataInst(mnem, code, flagType = "logic", \

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -146,6 +146,7 @@ let {{
     buildDataInst("eor", "Dest64 = Op164 ^ secOp;", buildCc = False)
     buildXSRegDataInst("eon", "Dest64 = Op164 ^ ~secOp;", buildCc = False)
     buildDataInst("cmp", "Dest64 = resTemp = Op164 - secOp;", "sub")
+    buildDataInst("neg", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("sub", "Dest64 = resTemp = Op164 - secOp;", "sub")
     buildDataInst("add", "Dest64 = resTemp = Op164 + secOp;", "add")
     buildXSRegDataInst("adc",

--- a/src/base/SConscript
+++ b/src/base/SConscript
@@ -71,6 +71,7 @@ Source('time.cc')
 Source('trace.cc')
 GTest('trie.test', 'trie.test.cc')
 Source('types.cc')
+Source('mem_data.cc')
 
 Source('loader/aout_object.cc')
 Source('loader/dtb_object.cc')

--- a/src/base/loader/symtab.cc
+++ b/src/base/loader/symtab.cc
@@ -52,6 +52,31 @@ SymbolTable::clear()
 }
 
 bool
+SymbolTable::insert_target(Addr address)
+{
+    ostringstream ostr;
+    string symbol;
+    string target;
+    Addr symAddr;
+
+    if (!findNearestSymbol(address, symbol, symAddr))
+        return false;
+
+    // Avoid adding named branch target (label) for a named symbol.
+    if (address == symAddr)
+        return true;
+
+    // Avoid adding duplicated label.
+    if (findLabel(address, target))
+        return true;
+
+    ostr << symbol << "_" << address - symAddr;
+    targetTable.insert(make_pair(address, ostr.str()));
+
+    return true;
+}
+
+bool
 SymbolTable::insert(Addr address, string symbol)
 {
     if (symbol.empty())

--- a/src/base/loader/symtab.hh
+++ b/src/base/loader/symtab.hh
@@ -48,6 +48,7 @@ class SymbolTable
   private:
     ATable addrTable;
     STable symbolTable;
+    ATable targetTable;
 
   private:
     bool
@@ -70,10 +71,12 @@ class SymbolTable
 
     void clear();
     bool insert(Addr address, std::string symbol);
+    bool insert_target(Addr address);
     bool load(const std::string &file);
 
     const ATable &getAddrTable() const { return addrTable; }
     const STable &getSymbolTable() const { return symbolTable; }
+    const ATable &getTargetTable() const { return targetTable; }
 
   public:
     void serialize(const std::string &base, CheckpointOut &cp) const;
@@ -91,6 +94,30 @@ class SymbolTable
         // address. For simplicity, just return the first one.
         symbol = (*i).second;
         return true;
+    }
+
+    bool
+    findTarget(Addr address, std::string &target) const
+    {
+        ATable::const_iterator i = targetTable.find(address);
+        if (i == targetTable.end())
+            return false;
+
+        target = (*i).second;
+        return true;
+    }
+
+    bool
+    findLabel(Addr address, std::string &label) const
+    {
+        Addr target;
+
+        if (findNearestSymbol(address, label, target) &&
+            target == address)
+            return true;
+
+        // Only works when enableTarget is true.
+        return findTarget(address, label);
     }
 
     bool

--- a/src/base/mem_data.cc
+++ b/src/base/mem_data.cc
@@ -1,0 +1,18 @@
+#include "base/mem_data.hh"
+
+#define IS_ALIGNED_ADDR(x, a)	(((x) & ((Addr)(a) - 1)) == 0)
+#define MAX_MEM_DATA_SIZE	64
+
+bool
+MemData::merge(MemData &data)
+{
+    if (size < MAX_MEM_DATA_SIZE &&
+        data.addr == addr + size &&
+        data.size == size &&
+        IS_ALIGNED_ADDR(addr, size << 1)) {
+        value |= (data.value << (8 * size));
+        size <<= 1;
+        return true;
+    }
+    return false;
+}

--- a/src/base/mem_data.hh
+++ b/src/base/mem_data.hh
@@ -1,0 +1,23 @@
+
+#ifndef __CPU_MEM_DATA_HH__
+#define __CPU_MEM_DATA_HH__
+
+#include <memory>
+#include <vector>
+
+#include "arch/types.hh"
+#include "base/types.hh"
+
+class MemData {
+  public:
+    Addr addr;
+    Addr size;
+    uint64_t value;
+
+  public:
+    MemData(Addr _addr, uint8_t _value)
+      : addr(_addr), size(1), value((uint64_t)_value) {}
+    bool merge(MemData &data);
+};
+
+#endif /* __CPU_MEM_DATA_HH__ */

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -212,6 +212,8 @@ class BaseCPU(ClockedObject):
         "terminate when any thread reaches this inst count")
     simpoint_start_insts = VectorParam.Counter([],
         "starting instruction counts of simpoints")
+    simpoint_disassembly_path = Param.String("",
+        "Path to save simpoint disassembly")
     max_loads_all_threads = Param.Counter(0,
         "terminate when all threads have reached this load count")
     max_loads_any_thread = Param.Counter(0,

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -948,8 +948,63 @@ BaseCPU::markBranched(Addr address)
 }
 
 bool
+BaseCPU::find_mem_data(Addr addr, std::list<MemData> &data_array)
+{
+    for (auto &item : data_array) {
+        if (addr >= item.addr && addr < item.addr + item.size)
+            return true;
+    }
+    return false;
+}
+
+void
+BaseCPU::insert_mem_data(Addr addr, uint8_t value,
+                         std::list<MemData> &data_array)
+{
+    MemData data(addr, value);
+    bool merged = false;
+
+again:
+    for (auto it = data_array.begin(); it != data_array.end(); ++it) {
+        if ((*it).addr > data.addr) {
+            data_array.insert(it, data);
+            merged = true;
+            break;
+        }
+        if ((*it).merge(data)) {
+            data = *it;
+            data_array.erase(it);
+            goto again;
+        }
+    }
+    if (!merged)
+        data_array.push_back(data);
+}
+
+bool
 BaseCPU::markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value)
 {
+    int i;
+
+    // TODO: Try to skip stack accesses at an early stage
+    if (size > 8) {
+        std::cout << "WARN: Invalid access size ";
+        std::cout << std::dec << size << "." << std::endl;
+        size = 8;
+    }
+    for (i = 0; i < size; i++) {
+        Addr byteAddr = addr + i;
+        uint8_t byteData = (uint8_t)(value >> (i * 8));
+
+        if (!find_mem_data(byteAddr, reads) &&
+            !find_mem_data(byteAddr, writes)) {
+            // First time access
+            if (opcls == MemReadOp)
+                insert_mem_data(byteAddr, byteData, reads);
+            else
+                insert_mem_data(byteAddr, byteData, writes);
+        }
+    }
     return true;
 }
 

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -131,6 +131,7 @@ BaseCPU::BaseCPU(Params *p, bool is_checker)
       _dataMasterId(p->system->getMasterId(this, "data")),
       _taskId(ContextSwitchTaskId::Unknown), _pid(invldPid),
       _switchedOut(p->switched_out), _cacheLineSize(p->system->cacheLineSize()),
+      _simpointStarted(false),
       interrupts(p->interrupts), profileEvent(NULL),
       numThreads(p->numThreads), system(p->system),
       previousCycle(0), previousState(CPU_STATE_SLEEP),
@@ -179,6 +180,15 @@ BaseCPU::BaseCPU(Params *p, bool is_checker)
         const char *cause = "simpoint starting point found";
         for (size_t i = 0; i < p->simpoint_start_insts.size(); ++i)
             scheduleInstStop(0, p->simpoint_start_insts[i], cause);
+    }
+    // Set up instruction log file stream
+    std::string simpoint_asm_path = p->simpoint_disassembly_path.c_str();
+    if (!simpoint_asm_path.empty()) {
+        simpoint_asm.open(simpoint_asm_path);
+        if (simpoint_asm.is_open()) {
+            std::cout << "Disassembling simpoint to ";
+            std::cout << simpoint_asm_path << "." << std::endl;
+        }
     }
 
     if (p->max_insts_all_threads != 0) {
@@ -275,6 +285,7 @@ BaseCPU::~BaseCPU()
     delete profileEvent;
     delete[] comLoadEventQueue;
     delete[] comInstEventQueue;
+    simpoint_asm.close();
 }
 
 void
@@ -863,4 +874,88 @@ bool
 BaseCPU::waitForRemoteGDB() const
 {
     return params()->wait_for_remote_gdb;
+}
+
+bool
+BaseCPU::markExecuted(Addr address)
+{
+    int size = symbols.size();
+    int i = 0;
+    std::string sym_str;
+    Addr funcStart, funcEnd;
+
+    if (!debugSymbolTable)
+        return false;
+
+    if (!debugSymbolTable->findNearestSymbol(address, sym_str,
+                                             funcStart, funcEnd)) {
+        funcStart = address;
+        funcEnd = address + 1;
+    }
+
+    while (i < size) {
+        if (funcStart == symbols[i])
+            return false;
+
+        if (funcStart < symbols[i] &&
+            (i == 0 || funcStart > symbols[i - 1]))
+            break;
+        i++;
+    };
+    symbols.insert(symbols.begin() + i, funcStart);
+    return true;
+}
+
+bool
+BaseCPU::markStarted(Addr address)
+{
+    if (!_simpointStarted) {
+        simpoint_entry = address;
+        dumpSimulatedRegisters();
+        _simpointStarted = true;
+    }
+
+    return markExecuted(address);
+}
+
+bool
+BaseCPU::markBranched(Addr address)
+{
+    int size;
+    int i;
+
+    size = symbols.size();
+    i = 0;
+    while (i < size) {
+        if (address == symbols[i])
+            return false;
+        i++;
+    }
+
+    size = branches.size();
+    i = 0;
+    while (i < size) {
+        if (address == branches[i])
+            return false;
+
+        if (address < branches[i] &&
+            (i == 0 || address > branches[i - 1]))
+            break;
+        i++;
+    };
+    branches.insert(branches.begin() + i, address);
+    return true;
+}
+
+bool
+BaseCPU::markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value)
+{
+    return true;
+}
+
+void
+sliceSimPoint()
+{
+    std::cout << "Slicing SimPoint..." << std::endl;
+    BaseCPU::dumpSimulatedInsts();
 }

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -46,6 +46,7 @@
 #ifndef __CPU_BASE_HH__
 #define __CPU_BASE_HH__
 
+#include <fstream>
 #include <vector>
 
 // Before we do anything else, check if this build is the NULL ISA,
@@ -150,6 +151,12 @@ class BaseCPU : public ClockedObject
     /** Cache the cache line size that we get from the system */
     const unsigned int _cacheLineSize;
 
+    /* Is SimPoint entry point set? */
+    bool _simpointStarted;
+
+    /* SimPoint simulation entry point */
+    Addr simpoint_entry;
+
   public:
 
     /**
@@ -209,6 +216,8 @@ class BaseCPU : public ClockedObject
 
   protected:
     std::vector<TheISA::Interrupts*> interrupts;
+    std::vector<Addr> symbols;
+    std::vector<Addr> branches;
 
   public:
     TheISA::Interrupts *
@@ -220,6 +229,13 @@ class BaseCPU : public ClockedObject
         assert(interrupts.size() > tid);
         return interrupts[tid];
     }
+
+    bool markStarted(Addr address);
+    bool markExecuted(Addr address);
+    bool markBranched(Addr address);
+    bool markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value);
+    virtual void dumpSimulatedRegisters() {};
+    virtual void dumpSimulatedSymbols() {};
 
     virtual void wakeup(ThreadID tid) = 0;
 
@@ -259,6 +275,8 @@ class BaseCPU : public ClockedObject
 
   public:
 
+    // Log file of the disassembled instructions executed by the CPU
+    std::ofstream simpoint_asm;
 
     /** Invalid or unknown Pid. Possible when operating system is not present
      *  or has not assigned a pid yet */
@@ -603,6 +621,13 @@ class BaseCPU : public ClockedObject
             total += cpuList[i]->totalInsts();
 
         return total;
+    }
+
+    static void dumpSimulatedInsts()
+    {
+        int size = cpuList.size();
+        for (int i = 0; i < size; ++i)
+            cpuList[i]->dumpSimulatedSymbols();
     }
 
     static Counter numSimulatedOps()

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -58,6 +58,7 @@
 #include "arch/interrupts.hh"
 #include "arch/isa_traits.hh"
 #include "arch/microcode_rom.hh"
+#include "base/mem_data.hh"
 #include "base/statistics.hh"
 #include "sim/clocked_object.hh"
 #include "sim/eventq.hh"
@@ -218,6 +219,8 @@ class BaseCPU : public ClockedObject
     std::vector<TheISA::Interrupts*> interrupts;
     std::vector<Addr> symbols;
     std::vector<Addr> branches;
+    std::list<MemData> reads;
+    std::list<MemData> writes;
 
   public:
     TheISA::Interrupts *
@@ -234,8 +237,12 @@ class BaseCPU : public ClockedObject
     bool markExecuted(Addr address);
     bool markBranched(Addr address);
     bool markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value);
+    bool find_mem_data(Addr addr, std::list<MemData> &data_array);
+    void insert_mem_data(Addr addr, uint8_t value,
+                         std::list<MemData> &data_array);
     virtual void dumpSimulatedRegisters() {};
     virtual void dumpSimulatedSymbols() {};
+    virtual void dumpSimulatedMemories() {};
 
     virtual void wakeup(ThreadID tid) = 0;
 

--- a/src/cpu/exetrace.cc
+++ b/src/cpu/exetrace.cc
@@ -71,7 +71,13 @@ ExeTracerRecord::dumpTicks(ostream &outs)
 void
 Trace::ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
 {
+    BaseCPU *cpu = thread->getCpuPtr();
     ostream &outs = Trace::output();
+    OpClass opcls = inst->opClass();
+
+    if (opcls == MemReadOp || opcls == MemWriteOp) {
+        cpu->markAccessed(opcls, addr, size, data.as_int);
+    }
 
     if (!Debug::ExecUser || !Debug::ExecKernel) {
         bool in_user_mode = TheISA::inUserMode(thread);
@@ -122,7 +128,7 @@ Trace::ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
         outs << " : ";
 
         if (Debug::ExecOpClass) {
-            outs << Enums::OpClassStrings[inst->opClass()] << " : ";
+            outs << Enums::OpClassStrings[opcls] << " : ";
         }
 
         if (Debug::ExecResult && !predicate) {

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -553,9 +553,13 @@ BaseSimpleCPU::preExecute()
     //If we decoded an instruction this "tick", record information about it.
     if (curStaticInst) {
 #if TRACING_ON
-        traceData = tracer->getInstRecord(curTick(), thread->getTC(),
-                curStaticInst, thread->pcState(), curMacroStaticInst);
+        PCState pcState = thread->pcState();
 
+        // Mark the PC related symbol as executed.
+        markStarted(pcState.instAddr());
+
+        traceData = tracer->getInstRecord(curTick(), thread->getTC(),
+                curStaticInst, pcState, curMacroStaticInst);
         DPRINTF(Decode,"Decode: Decoded %s instruction: %#x\n",
                 curStaticInst->getName(), curStaticInst->machInst);
 #endif // TRACING_ON

--- a/src/cpu/simple/noncaching.cc
+++ b/src/cpu/simple/noncaching.cc
@@ -74,6 +74,19 @@ NonCachingSimpleCPUParams::create()
 }
 
 void
+NonCachingSimpleCPU::dumpSimulatedMemories()
+{
+    SimpleExecContext &t_info = *threadInfo[curThread];
+    SimpleThread* thread = t_info.thread;
+
+    for (auto &item : reads) {
+        thread->getIsaPtr()->dumpContextMems(this, thread,
+                                             item.addr, item.size, item.value);
+    }
+    thread->getIsaPtr()->dumpContextRegsLate(this, thread);
+}
+
+void
 NonCachingSimpleCPU::dumpSimulatedSymbols()
 {
     if (!debugSymbolTable || !simpoint_asm.is_open())
@@ -95,7 +108,7 @@ NonCachingSimpleCPU::dumpSimulatedSymbols()
     StaticInstPtr instPtr;
     std::string disassembly;
     TheISA::PCState pc;
-    bool doDump;
+    bool doDump, dumpedMemories = false;
 
     while (i < size) {
         if (!symtab->findNearestSymbol(symbols[i], sym_str,
@@ -103,10 +116,16 @@ NonCachingSimpleCPU::dumpSimulatedSymbols()
             return;
         if (funcStart != symbols[i])
             return;
-        simpoint_asm << std::endl << sym_str << ":" << std::endl;
         doDump = false;
 
 dumpAgain:
+        if (doDump) {
+            if (i == 0 && !dumpedMemories) {
+                dumpSimulatedMemories();
+                dumpedMemories = true;
+            }
+            simpoint_asm << std::endl << sym_str << ":" << std::endl;
+        }
         addr = funcStart;
         pc = thread->pcState();
         pc.set(addr);
@@ -202,5 +221,5 @@ NonCachingSimpleCPU::dumpSimulatedRegisters()
     SimpleThread* thread = t_info.thread;
 
     std::cout << "Dumping registers..." << std::endl;
-    thread->getIsaPtr()->dumpContextRegs(this, thread, ::readMem);
+    thread->getIsaPtr()->dumpContextRegsEarly(this, thread, ::readMem);
 }

--- a/src/cpu/simple/noncaching.cc
+++ b/src/cpu/simple/noncaching.cc
@@ -72,3 +72,135 @@ NonCachingSimpleCPUParams::create()
         fatal("only one workload allowed");
     return new NonCachingSimpleCPU(this);
 }
+
+void
+NonCachingSimpleCPU::dumpSimulatedSymbols()
+{
+    if (!debugSymbolTable || !simpoint_asm.is_open())
+        return;
+
+    if (curThread != 0)
+        fatal("Execution disassembly currently does not support SMT");
+
+    SimpleExecContext &t_info = *threadInfo[curThread];
+    SimpleThread* thread = t_info.thread;
+    TheISA::Decoder *decoder = &(thread->decoder);
+    SymbolTable *symtab = debugSymbolTable;
+
+    int size = symbols.size();
+    int i = 0;
+    std::string sym_str;
+    std::string lab_str;
+    Addr funcStart, funcEnd, addr, target;
+    StaticInstPtr instPtr;
+    std::string disassembly;
+    TheISA::PCState pc;
+    bool doDump;
+
+    while (i < size) {
+        if (!symtab->findNearestSymbol(symbols[i], sym_str,
+                                       funcStart, funcEnd))
+            return;
+        if (funcStart != symbols[i])
+            return;
+        simpoint_asm << std::endl << sym_str << ":" << std::endl;
+        doDump = false;
+
+dumpAgain:
+        addr = funcStart;
+        pc = thread->pcState();
+        pc.set(addr);
+        thread->pcState(pc);
+        t_info.fetchOffset = 0;
+
+        while (addr < funcEnd) {
+            if (doDump && simpoint_entry == addr)
+                simpoint_asm << "simpoint_start:" << std::endl;
+            if (doDump && symtab->findTarget(addr, lab_str))
+                simpoint_asm << lab_str << ":" << std::endl;
+
+            Fault fault = NoFault;
+            ifetch_req->taskId(taskId());
+            setupFetchRequest(ifetch_req);
+            fault = thread->itb->translateAtomic(ifetch_req,
+                                                 thread->getTC(),
+                                                 BaseTLB::Execute);
+            if (fault == NoFault) {
+                Packet ifetch_pkt = Packet(ifetch_req, MemCmd::ReadReq);
+                ifetch_pkt.dataStatic(&inst);
+                sendPacket(icachePort, &ifetch_pkt);
+                gtoh(inst);
+
+                Addr fetchPC = (addr & PCMask) + t_info.fetchOffset;
+                decoder->moreBytes(pc, fetchPC, inst);
+                instPtr = decoder->decode(pc);
+                if (instPtr) {
+                    t_info.stayAtPC = false;
+                    thread->pcState(pc);
+                } else {
+                    fatal("Fetching MicroOP?");
+                    t_info.stayAtPC = true;
+                    t_info.fetchOffset += sizeof(MachInst);
+                }
+
+                if (doDump) {
+                    disassembly = instPtr->disassemble(addr, symtab, true);
+                    simpoint_asm << disassembly << std::endl;
+                } else {
+                    if (instPtr->markTarget(addr, target, symtab) &&
+                        symtab->findNearestSymbol(target, sym_str, addr) &&
+                        addr == target) {
+                        markBranched(target);
+                    }
+                }
+            }
+            if (fault != NoFault || !t_info.stayAtPC)
+                advancePC(fault);
+            pc = thread->pcState();
+            addr = pc.instAddr();
+        }
+        if (!doDump) {
+            doDump = true;
+            goto dumpAgain;
+        }
+        i++;
+    }
+
+    size = branches.size();
+    i = 0;
+    while (i < size) {
+        if (!symtab->findNearestSymbol(branches[i], sym_str,
+                                       funcStart, funcEnd))
+            return;
+        if (funcStart != branches[i])
+            return;
+        if (i == 0)
+            simpoint_asm << std::endl;
+        simpoint_asm << sym_str << ":" << std::endl;
+        i++;
+    }
+    thread->getIsaPtr()->dumpCallReturn(this);
+}
+
+static bool
+readMem(BaseCPU *cpu, Addr addr, uint8_t *data,
+        unsigned size, Request::Flags flags)
+{
+    Fault fault = NoFault;
+    NonCachingSimpleCPU *this_cpu = dynamic_cast<NonCachingSimpleCPU *>(cpu);
+
+    if (!this_cpu)
+        return false;
+    fault = this_cpu->readMem(addr, data, size, flags);
+    return fault == NoFault ? true : false;
+}
+
+void
+NonCachingSimpleCPU::dumpSimulatedRegisters()
+{
+    SimpleExecContext &t_info = *threadInfo[curThread];
+    SimpleThread* thread = t_info.thread;
+
+    std::cout << "Dumping registers..." << std::endl;
+    thread->getIsaPtr()->dumpContextRegs(this, thread, ::readMem);
+}

--- a/src/cpu/simple/noncaching.hh
+++ b/src/cpu/simple/noncaching.hh
@@ -54,6 +54,9 @@ class NonCachingSimpleCPU : public AtomicSimpleCPU
 
     void verifyMemoryMode() const override;
 
+    void dumpSimulatedSymbols();
+    void dumpSimulatedRegisters();
+
   protected:
     Tick sendPacket(MasterPort &port, const PacketPtr &pkt) override;
 };

--- a/src/cpu/simple/noncaching.hh
+++ b/src/cpu/simple/noncaching.hh
@@ -56,6 +56,7 @@ class NonCachingSimpleCPU : public AtomicSimpleCPU
 
     void dumpSimulatedSymbols();
     void dumpSimulatedRegisters();
+    void dumpSimulatedMemories();
 
   protected:
     Tick sendPacket(MasterPort &port, const PacketPtr &pkt) override;

--- a/src/cpu/static_inst.cc
+++ b/src/cpu/static_inst.cc
@@ -119,9 +119,20 @@ StaticInst::branchTarget(ThreadContext *tc) const
     M5_DUMMY_RETURN;
 }
 
-const string &
-StaticInst::disassemble(Addr pc, const SymbolTable *symtab) const
+bool
+StaticInst::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
 {
+    return false;
+}
+
+const string &
+StaticInst::disassemble(Addr pc, const SymbolTable *symtab,
+                        bool redisasm) const
+{
+    if (cachedDisassembly && redisasm) {
+        delete cachedDisassembly;
+        cachedDisassembly = 0;
+    }
     if (!cachedDisassembly)
         cachedDisassembly = new string(generateDisassembly(pc, symtab));
 

--- a/src/cpu/static_inst.hh
+++ b/src/cpu/static_inst.hh
@@ -324,7 +324,7 @@ class StaticInst : public RefCounted, public StaticInstFlags
      * should not be cached, this function should be overridden directly.
      */
     virtual const std::string &disassemble(Addr pc,
-        const SymbolTable *symtab = 0) const;
+        const SymbolTable *symtab = 0, bool redisasm = false) const;
 
     /**
      * Print a separator separated list of this instruction's set flag
@@ -334,6 +334,14 @@ class StaticInst : public RefCounted, public StaticInstFlags
 
     /// Return name of machine instruction
     std::string getName() { return mnemonic; }
+
+    /**
+     * Can be overridden by the immediate branch instructions, to save
+     * the branch target into the symbol table.
+     * Returning true means this instruction is a branch instruction.
+     */
+    virtual bool
+    markTarget(Addr pc, Addr &Target, SymbolTable *symtab);
 
   protected:
     template<typename T>

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -178,6 +178,9 @@ def simulate(*args, **kwargs):
 
     return _m5.event.simulate(*args, **kwargs)
 
+def sliceSimPoint(*args, **kwargs):
+    return _m5.event.sliceSimPoint(*args, **kwargs)
+
 def drain():
     """Drain the simulator in preparation of a checkpoint or memory mode
     switch.

--- a/src/python/pybind11/event.cc
+++ b/src/python/pybind11/event.cc
@@ -109,6 +109,7 @@ pybind_init_event(py::module &m_native)
     m.def("simulate", &simulate,
           py::arg("ticks") = MaxTick);
     m.def("exitSimLoop", &exitSimLoop);
+    m.def("sliceSimPoint", &sliceSimPoint);
     m.def("getEventQueue", []() { return curEventQueue(); },
           py::return_value_policy::reference);
     m.def("setEventQueue", [](EventQueue *q) { return curEventQueue(q); });

--- a/src/sim/sim_exit.hh
+++ b/src/sim/sim_exit.hh
@@ -56,5 +56,6 @@ void exitSimLoop(const std::string &message, int exit_code = 0,
 /// any normal events which are schedule at the current time.
 void exitSimLoopNow(const std::string &message, int exit_code = 0,
                     Tick repeat = 0, bool serialize = false);
+void sliceSimPoint();
 
 #endif // __SIM_EXIT_HH__

--- a/util/term/term.c
+++ b/util/term/term.c
@@ -168,15 +168,6 @@ readwrite(int nfd)
             perror("Select Error:");
         }
 
-        if (n == 0) {
-            if (read(nfd, buf, 0) < 0)
-                return;
-            continue;
-        }
-
-        if (read(nfd, buf, 0) < 0)
-            return;
-
         if (FD_ISSET(nfd, &read_fds)) {
             if ((n = read(nfd, buf, sizeof(buf))) < 0)
                 return;


### PR DESCRIPTION
1. Find the nearest symbol and use "symbol <+/- offset>" for ADRP.
2. Fix format mistake for LDR/STR (register) post-index.
3. Width of Rn is fixed to 64 in LDRx/STRx.