### PR TITLE
ARM64: Add CMN as alias of ADDS(immediate, shifted register and extended register)

### DIFF
--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -107,7 +107,10 @@ namespace Aarch64
               case 0x0:
                 return new AddXImm(machInst, rdsp, rnsp, imm);
               case 0x1:
-                return new AddXImmCc(machInst, rdzr, rnsp, imm);
+                if (rdzr == INTREG_ZERO)
+                  return new CmnXImmCc(machInst, rdzr, rnsp, imm);
+                else
+                  return new AddXImmCc(machInst, rdzr, rnsp, imm);
               case 0x2:
                 return new SubXImm(machInst, rdsp, rnsp, imm);
               case 0x3:

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -99,7 +99,10 @@ let {{
         ccCode = createCcCode64(carryCode64[flagType], overflowCode64[flagType])
         Name = mnem.capitalize() + suffix
         iop = InstObjParams(mnem, Name, base, code)
-        iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
+        if (mnem == "cmn"):
+            iopCc = InstObjParams(mnem, Name + "Cc", base, code + ccCode)
+        else:
+            iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
 
         def subst(iop):
             global header_output, decoder_output, exec_output
@@ -143,6 +146,7 @@ let {{
     buildDataInst("eor", "Dest64 = Op164 ^ secOp;", buildCc = False)
     buildXSRegDataInst("eon", "Dest64 = Op164 ^ ~secOp;", buildCc = False)
     buildDataInst("sub", "Dest64 = resTemp = Op164 - secOp;", "sub")
+    buildDataInst("cmn", "Dest64 = resTemp = Op164 + secOp;", "add")
     buildDataInst("add", "Dest64 = resTemp = Op164 + secOp;", "add")
     buildXSRegDataInst("adc",
             "Dest64 = resTemp = Op164 + secOp + %s;" % oldC, "add")


### PR DESCRIPTION
The ADDS instructions including ADDS (immediate), ADDS (shifted register) and ADDS (extended register) are aliased as CMN instructions, when Rd is INTER_ZERO. While the original GEM5 doesn't do this when generating disassembly. This patch fixes this problem.

Change-Id: Id5c3b97d1e150a6e566caad6724b1143a9170109
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>
Signed-off-by: Lv Zheng <zhenglv@hotmail.com>