### PR TITLE
ARM64: Add TST as alias of ANDS(immediate and shifted register)

### DIFF
--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -155,7 +155,10 @@ namespace Aarch64
               case 0x2:
                 return new EorXImm(machInst, rdsp, rn, imm);
               case 0x3:
-                return new AndXImmCc(machInst, rdzr, rn, imm);
+                if (rdzr == INTREG_ZERO)
+                  return new TstXImmCc(machInst, rdzr, rn, imm);
+                else
+                  return new AndXImmCc(machInst, rdzr, rn, imm);
               default:
                 M5_UNREACHABLE;
             }
@@ -1250,7 +1253,10 @@ namespace Aarch64
               case 0x5:
                 return new EonXSReg(machInst, rdzr, rn, rm, imm6, type);
               case 0x6:
-                return new AndXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                if (rdzr == INTREG_ZERO)
+                  return new TstXSRegCc(machInst, rdzr, rn, rm, imm6, type);
+                else
+                  return new AndXSRegCc(machInst, rdzr, rn, rm, imm6, type);
               case 0x7:
                 return new BicXSRegCc(machInst, rdzr, rn, rm, imm6, type);
               default:

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -99,7 +99,10 @@ let {{
         ccCode = createCcCode64(carryCode64[flagType], overflowCode64[flagType])
         Name = mnem.capitalize() + suffix
         iop = InstObjParams(mnem, Name, base, code)
-        iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
+        if (mnem == "tst"):
+            iopCc = InstObjParams(mnem, Name + "Cc", base, code + ccCode)
+        else:
+            iopCc = InstObjParams(mnem + "s", Name + "Cc", base, code + ccCode)
 
         def subst(iop):
             global header_output, decoder_output, exec_output
@@ -139,6 +142,7 @@ let {{
     buildXImmDataInst("adr", "Dest64 = RawPC + imm", buildCc = False);
     buildXImmDataInst("adrp", "Dest64 = (RawPC & ~mask(12)) + imm",
                       buildCc = False);
+    buildDataInst("tst", "Dest64 = resTemp = Op164 & secOp;")
     buildDataInst("and", "Dest64 = resTemp = Op164 & secOp;")
     buildDataInst("eor", "Dest64 = Op164 ^ secOp;", buildCc = False)
     buildXSRegDataInst("eon", "Dest64 = Op164 ^ ~secOp;", buildCc = False)


### PR DESCRIPTION
The ANDS instructions including ANDS (immediate) and ANDS (shifted register) are aliased as TST instructions, when Rd is INTER_ZERO. While the original GEM5 doesn't do this when generating disassembly. This patch fixes this problem.

Change-Id: I6b3d6bf673da8dfc82f1034823114c795bde8b4e
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>
Signed-off-by: Lv Zheng <zhenglv@hotmail.com>