### PR TITLE
 ARM64: Fix bit position for TBZ and TBNZ

### DIFF
--- a/src/arch/arm/insts/branch64.cc
+++ b/src/arch/arm/insts/branch64.cc
@@ -138,7 +138,8 @@ BranchImmImmReg64::generateDisassembly(
     std::stringstream ss;
     printMnemonic(ss, "", false);
     printIntReg(ss, op1);
-    ccprintf(ss, ", #%#x, ", imm1);
+    int bit_pos = (bits(machInst, 31, 31) << 5) +  bits(machInst, 23, 19);
+    ccprintf(ss, ", #%d, ", bit_pos);
     printTarget(ss, pc + imm2, symtab);
     return ss.str();
 }


### PR DESCRIPTION
In instructions TBZ and TBNZ, the bit position (or bit number) to be tested is encoded in bits 31 and 23 to 19. The origin GEM5 generates a wrong value in disassembly. This problem is fixed.

Change-Id: I7a8e16f5dd0814f04cf4e937065b04479145d55c
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>
Signed-off-by: Lv Zheng <zhenglv@hotmail.com>