### PR TITLE
ARM64: Fix LDR/STR (register) post-indexed

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -148,7 +148,8 @@ MemoryPostIndex64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     startDisassembly(ss);
     if (imm)
         ccprintf(ss, "], #%d", imm);
-    ccprintf(ss, "]");
+    else
+        ccprintf(ss, "]");
     return ss.str();
 }
 


### PR DESCRIPTION
The origin GEM5 does not give an right format of disassembly for the LDR/STR (register) post-indexed instructions. This patch fixes the problem.

Change-Id: I85d89a578f5fc212cf35dc1d76d695a782213f91
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>
Signed-off-by: Lv Zheng <zhenglv@hotmail.com>