### PR TITLE
ARM64: Fix Rd width of LDR (literal) disassembly

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -189,8 +189,14 @@ std::string
 MemoryLiteral64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    if (size == 0)
+        rd_width = 32;
+    else
+        rd_width = 64;
     printMnemonic(ss, "", false);
-    printIntReg(ss, dest);
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", #%d", pc + imm);
     return ss.str();
 }


### PR DESCRIPTION
The width of Rd LDR (literal) could be 32 or 64 bits, depending on the size field of machine code. While the origin GEM5 always gives 64 bits Rd in disassembly. This patch fixes the problem.

Change-Id: I1397c3ecfad393834c8d99721f6c82906e64794d
Signed-off-by: Ian Jiang ianjiang.ict@gmail.com
Signed-off-by: Lv Zheng zhenglv@hotmail.com