### PR TITLE
ARM64: Fix register width of Load/Store (immediate) Pre/Post-Index

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -98,6 +98,22 @@ MemoryImm64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     return ss.str();
 }
 
+void
+MemoryImm64::startDisassemblyIndex(std::ostream &os) const
+{
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    uint32_t opc = bits(machInst, 23, 22);
+    if (size == 0x3 || opc == 0x2)
+        rd_width = 64;
+    else
+        rd_width = 32;
+    printMnemonic(os, "", false);
+    printIntReg(os, dest, rd_width);
+    ccprintf(os, ", [");
+    printIntReg(os, base, 64);
+}
+
 std::string
 MemoryDImm64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
@@ -136,7 +152,7 @@ std::string
 MemoryPreIndex64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
-    startDisassembly(ss);
+    startDisassemblyIndex(ss);
     ccprintf(ss, ", #%d]!", imm);
     return ss.str();
 }
@@ -145,10 +161,8 @@ std::string
 MemoryPostIndex64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
-    startDisassembly(ss);
-    if (imm)
-        ccprintf(ss, "], #%d", imm);
-    ccprintf(ss, "]");
+    startDisassemblyIndex(ss);
+    ccprintf(ss, "], #%d", imm);
     return ss.str();
 }
 

--- a/src/arch/arm/insts/mem64.hh
+++ b/src/arch/arm/insts/mem64.hh
@@ -141,6 +141,8 @@ class MemoryImm64 : public Memory64
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+
+    void startDisassemblyIndex(std::ostream &os) const;
 };
 
 class MemoryDImm64 : public MemoryImm64


### PR DESCRIPTION
The width of Rd Load/Store (immediate) Pre-Index or Post-Index  could be 32 or 64 bits, depending on the size and opc fields of the machine code. While the origin GEM5 always gives 64 bits Rd in disassembly. This patch fixes the problem.

Change-Id: I291edede2bd668b8cebef9397a1329b134546491
Signed-off-by: Ian Jiang ianjiang.ict@gmail.com
Signed-off-by: Lv Zheng zhenglv@hotmail.com