### PR TITLE
ARM64: Fix disassembly Rd width of Load/Store with immediate

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -91,7 +91,17 @@ std::string
 MemoryImm64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
-    startDisassembly(ss);
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    uint32_t opc = bits(machInst, 23, 22);
+    if (size == 0x3 || opc == 0x2)
+       rd_width = 64;
+    else
+       rd_width = 32;
+    printMnemonic(ss, "", false);
+    printIntReg(ss, dest, rd_width);
+    ccprintf(ss, ", [");
+    printIntReg(ss, base, 64);
     if (imm)
         ccprintf(ss, ", #%d", imm);
     ccprintf(ss, "]");


### PR DESCRIPTION
In Load/Store instructions with immediate, including immediate unsigned offset, register unscaled offset and unprivileged, the Rd width could be 32 or 64 bits, depending on the size and opc fields of the machine code. While the orgin GEM5 gives a 64 bits width Rd in disassembly. This patch fixes the problem.

Change-Id: I2485259135db7d2cabed6cf92ab25a89e21cc741
Signed-off-by: Ian Jiang ianjiang.ict@gmail.com
Signed-off-by: Lv Zheng zhenglv@hotmail.com