### PR TITLE
ARM64: Fix register width in disassembly for Load/Store instructions

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -102,10 +102,16 @@ std::string
 MemoryDImm64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    if (size == 3)
+        rd_width = 64;
+    else
+        rd_width = 32;
     printMnemonic(ss, "", false);
-    printIntReg(ss, dest);
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", ");
-    printIntReg(ss, dest2);
+    printIntReg(ss, dest2, rd_width);
     ccprintf(ss, ", [");
     printIntReg(ss, base);
     if (imm)
@@ -118,12 +124,20 @@ std::string
 MemoryDImmEx64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    if (size == 3)
+        rd_width = 64;
+    else
+        rd_width = 32;
     printMnemonic(ss, "", false);
-    printIntReg(ss, result);
+    if (result != INTREG_X31) {
+        printIntReg(ss, result, 32);
+        ccprintf(ss, ", ");
+    }
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", ");
-    printIntReg(ss, dest);
-    ccprintf(ss, ", ");
-    printIntReg(ss, dest2);
+    printIntReg(ss, dest2, rd_width);
     ccprintf(ss, ", [");
     printIntReg(ss, base);
     if (imm)
@@ -166,7 +180,16 @@ std::string
 MemoryRaw64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
-    startDisassembly(ss);
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    if (size == 3)
+        rd_width = 64;
+    else
+        rd_width = 32;
+    printMnemonic(ss, "", false);
+    printIntReg(ss, dest, rd_width);
+    ccprintf(ss, ", [");
+    printIntReg(ss, base, 64);
     ccprintf(ss, "]");
     return ss.str();
 }
@@ -175,12 +198,20 @@ std::string
 MemoryEx64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    int rd_width;
+    uint32_t size = bits(machInst, 31, 30);
+    if (size == 3)
+        rd_width = 64;
+    else
+        rd_width = 32;
     printMnemonic(ss, "", false);
-    printIntReg(ss, dest);
-    ccprintf(ss, ", ");
-    printIntReg(ss, result);
+    if (result != INTREG_X31) {
+        printIntReg(ss, result, 32);
+        ccprintf(ss, ", ");
+    }
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", [");
-    printIntReg(ss, base);
+    printIntReg(ss, base, 64);
     ccprintf(ss, "]");
     return ss.str();
 }


### PR DESCRIPTION
For some Load/Store instructions including:
- Load-Exclusive/Store-Exclusive instructions
- Non-exclusive Load-Acquire and Store-Release instructions
- Exclusive Load-Acquire and Store-Release instructions
the width of Rd could be 32 or 64 bits, depending on the size field of the machine code, the width of Rs is always 32 bits, and the width of Rn (base register) is always 64 bits.
The origin GEM5 does not give the correct disassembly. This patch fixes the problem.

Change-Id: I3b38a8637b84af0f4e87df50226eaa72c59b1dd6