### PR TITLE
ARM64: Add MOV (wide immediate) as alias for MOVZ

### DIFF
--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -287,6 +287,27 @@ RegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 }
 
 std::string
+RegImmImmMovzOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    ccprintf(ss, ", #%d, LSL #%d", imm1, imm2);
+    return ss.str();
+}
+
+std::string
+RegImmImmMovzMovOp::generateDisassembly(Addr pc,
+                                        const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    ccprintf(ss, ", #%d", imm1 << imm2);
+    return ss.str();
+}
+
+std::string
 RegRegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;

--- a/src/arch/arm/insts/misc.hh
+++ b/src/arch/arm/insts/misc.hh
@@ -322,6 +322,41 @@ class RegImmImmOp : public PredOp
             Addr pc, const SymbolTable *symtab) const override;
 };
 
+class RegImmImmMovzOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovzOp(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
+                   IntRegIndex _dest, uint64_t _imm1, uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
+class RegImmImmMovzMovOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovzMovOp(const char *mnem, ExtMachInst _machInst,
+                       OpClass __opClass, IntRegIndex _dest, uint64_t _imm1,
+                       uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
 class RegRegImmImmOp : public PredOp
 {
   protected:

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -172,7 +172,10 @@ namespace Aarch64
               case 0x1:
                 return new Unknown64(machInst);
               case 0x2:
-                return new Movz(machInst, rdzr, imm16, hw * 16);
+                if (!((imm16 == 0) && (hw != 0)))
+                  return new MovzMov(machInst, rdzr, imm16, hw * 16);
+                else
+                  return new Movz(machInst, rdzr, imm16, hw * 16);
               case 0x3:
                 return new Movk(machInst, rdzr, imm16, hw * 16);
               default:

--- a/src/arch/arm/isa/insts/aarch64.isa
+++ b/src/arch/arm/isa/insts/aarch64.isa
@@ -39,10 +39,16 @@
 
 let {{
     movzCode = 'Dest64 = ((uint64_t)imm1) << imm2;'
-    movzIop = InstObjParams("movz", "Movz", "RegImmImmOp", movzCode, [])
+    movzIop = InstObjParams("movz", "Movz", "RegImmImmMovzOp", movzCode, [])
     header_output += RegImmImmOpDeclare.subst(movzIop)
     decoder_output += RegImmImmOpConstructor.subst(movzIop)
     exec_output += BasicExecute.subst(movzIop)
+
+    movzmovIop = InstObjParams("mov", "MovzMov", "RegImmImmMovzMovOp",
+                               movzCode, [])
+    header_output += RegImmImmOpDeclare.subst(movzmovIop)
+    decoder_output += RegImmImmOpConstructor.subst(movzmovIop)
+    exec_output += BasicExecute.subst(movzmovIop)
 
     movkCode = 'Dest64 = insertBits(Dest64, imm2 + 15, imm2, imm1);'
     movkIop = InstObjParams("movk", "Movk", "RegImmImmOp", movkCode, [])


### PR DESCRIPTION
The MOVZ instruction should be aliased to MOV (wide immediate) under certain condition. This patch adds this disassembling function to the original GEM5.

Change-Id: I1faab8687563ff05ed46af45f177612b87a56f00
Signed-off-by: Ian Jiang ianjiang.ict@gmail.com