### PR TITLE
ARM64: Fix disassembly for MOVZ, MOVN and MOVK

### DIFF
--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -308,6 +308,36 @@ RegImmImmMovzMovOp::generateDisassembly(Addr pc,
 }
 
 std::string
+RegImmImmMovnOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    if (imm2 != 0)
+        ccprintf(ss, ", #%d, LSL #%d", imm1, imm2);
+    else
+        ccprintf(ss, ", #%d", imm1);
+    return ss.str();
+}
+
+std::string
+RegImmImmMovnMovOp::generateDisassembly(Addr pc,
+                                        const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    uint32_t sf = bits(machInst, 31);
+    printMnemonic(ss);
+    if (sf) {
+        printIntReg(ss, dest, 64);
+        ccprintf(ss, ", #%d", ~(((uint64_t)imm1) << imm2));
+    } else {
+        printIntReg(ss, dest, 32);
+        ccprintf(ss, ", #%d", ~(((uint32_t)imm1) << imm2));
+    }
+    return ss.str();
+}
+
+std::string
 RegRegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;

--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -287,6 +287,19 @@ RegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 }
 
 std::string
+RegImmImmMovkOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    if (imm2 != 0)
+        ccprintf(ss, ", #%d, LSL #%d", imm1, imm2);
+    else
+        ccprintf(ss, ", #%d", imm1);
+    return ss.str();
+}
+
+std::string
 RegImmImmMovzOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;

--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -287,6 +287,27 @@ RegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 }
 
 std::string
+RegImmImmMovzOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    ccprintf(ss, ", #%d, LSL #%d", imm1, imm2);
+    return ss.str();
+}
+
+std::string
+RegImmImmMovzMovOp::generateDisassembly(Addr pc,
+                                        const SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, dest);
+    ccprintf(ss, ", #%d", imm1 << imm2);
+    return ss.str();
+}
+
+std::string
 RegRegImmImmOp::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;

--- a/src/arch/arm/insts/misc.hh
+++ b/src/arch/arm/insts/misc.hh
@@ -357,6 +357,41 @@ class RegImmImmMovzMovOp : public PredOp
             Addr pc, const SymbolTable *symtab) const override;
 };
 
+class RegImmImmMovnOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovnOp(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
+                   IntRegIndex _dest, uint64_t _imm1, uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
+class RegImmImmMovnMovOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovnMovOp(const char *mnem, ExtMachInst _machInst,
+                       OpClass __opClass, IntRegIndex _dest, uint64_t _imm1,
+                       uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
 class RegRegImmImmOp : public PredOp
 {
   protected:

--- a/src/arch/arm/insts/misc.hh
+++ b/src/arch/arm/insts/misc.hh
@@ -322,6 +322,41 @@ class RegImmImmOp : public PredOp
             Addr pc, const SymbolTable *symtab) const override;
 };
 
+class RegImmImmMovzOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovzOp(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
+                   IntRegIndex _dest, uint64_t _imm1, uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
+class RegImmImmMovzMovOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovzMovOp(const char *mnem, ExtMachInst _machInst,
+                       OpClass __opClass, IntRegIndex _dest, uint64_t _imm1,
+                       uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
 class RegRegImmImmOp : public PredOp
 {
   protected:

--- a/src/arch/arm/insts/misc.hh
+++ b/src/arch/arm/insts/misc.hh
@@ -322,6 +322,23 @@ class RegImmImmOp : public PredOp
             Addr pc, const SymbolTable *symtab) const override;
 };
 
+class RegImmImmMovkOp : public PredOp
+{
+  protected:
+    IntRegIndex dest;
+    uint64_t imm1;
+    uint64_t imm2;
+
+    RegImmImmMovkOp(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
+                   IntRegIndex _dest, uint64_t _imm1, uint64_t _imm2) :
+        PredOp(mnem, _machInst, __opClass),
+        dest(_dest), imm1(_imm1), imm2(_imm2)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const SymbolTable *symtab) const override;
+};
+
 class RegImmImmMovzOp : public PredOp
 {
   protected:

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -166,9 +166,14 @@ namespace Aarch64
             IntRegIndex rdzr = makeZero(rd);
             uint32_t imm16 = bits(machInst, 20, 5);
             uint32_t hw = bits(machInst, 22, 21);
+            uint32_t sf = bits(machInst, 31);
             switch (opc) {
               case 0x0:
-                return new Movn(machInst, rdzr, imm16, hw * 16);
+                if (((sf == 1) && (!((imm16 == 0) && (hw != 0)))) || ((sf == 0)
+                    && (!((imm16 == 0) && (hw != 0))) && (imm16 != 0xFFFF)))
+                  return new MovnMov(machInst, rdzr, imm16, hw * 16);
+                else
+                  return new Movn(machInst, rdzr, imm16, hw * 16);
               case 0x1:
                 return new Unknown64(machInst);
               case 0x2:

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -172,7 +172,10 @@ namespace Aarch64
               case 0x1:
                 return new Unknown64(machInst);
               case 0x2:
-                return new Movz(machInst, rdzr, imm16, hw * 16);
+                if (!((imm16 == 0) && (hw != 0)))
+                  return new MovzMov(machInst, rdzr, imm16, hw * 16);
+                else
+                  return new Movz(machInst, rdzr, imm16, hw * 16);
               case 0x3:
                 return new Movk(machInst, rdzr, imm16, hw * 16);
               default:

--- a/src/arch/arm/isa/insts/aarch64.isa
+++ b/src/arch/arm/isa/insts/aarch64.isa
@@ -57,8 +57,14 @@ let {{
     exec_output += BasicExecute.subst(movkIop)
 
     movnCode = 'Dest64 = ~(((uint64_t)imm1) << imm2);'
-    movnIop = InstObjParams("movn", "Movn", "RegImmImmOp", movnCode, [])
+    movnIop = InstObjParams("movn", "Movn", "RegImmImmMovnOp", movnCode, [])
     header_output += RegImmImmOpDeclare.subst(movnIop)
     decoder_output += RegImmImmOpConstructor.subst(movnIop)
     exec_output += BasicExecute.subst(movnIop)
+
+    movnmovIop = InstObjParams("mov", "MovnMov", "RegImmImmMovnMovOp",
+                               movnCode, [])
+    header_output += RegImmImmOpDeclare.subst(movnmovIop)
+    decoder_output += RegImmImmOpConstructor.subst(movnmovIop)
+    exec_output += BasicExecute.subst(movnmovIop)
 }};

--- a/src/arch/arm/isa/insts/aarch64.isa
+++ b/src/arch/arm/isa/insts/aarch64.isa
@@ -39,10 +39,16 @@
 
 let {{
     movzCode = 'Dest64 = ((uint64_t)imm1) << imm2;'
-    movzIop = InstObjParams("movz", "Movz", "RegImmImmOp", movzCode, [])
+    movzIop = InstObjParams("movz", "Movz", "RegImmImmMovzOp", movzCode, [])
     header_output += RegImmImmOpDeclare.subst(movzIop)
     decoder_output += RegImmImmOpConstructor.subst(movzIop)
     exec_output += BasicExecute.subst(movzIop)
+
+    movzmovIop = InstObjParams("mov", "MovzMov", "RegImmImmMovzMovOp",
+                               movzCode, [])
+    header_output += RegImmImmOpDeclare.subst(movzmovIop)
+    decoder_output += RegImmImmOpConstructor.subst(movzmovIop)
+    exec_output += BasicExecute.subst(movzmovIop)
 
     movkCode = 'Dest64 = insertBits(Dest64, imm2 + 15, imm2, imm1);'
     movkIop = InstObjParams("movk", "Movk", "RegImmImmOp", movkCode, [])

--- a/src/arch/arm/isa/insts/aarch64.isa
+++ b/src/arch/arm/isa/insts/aarch64.isa
@@ -51,7 +51,7 @@ let {{
     exec_output += BasicExecute.subst(movzmovIop)
 
     movkCode = 'Dest64 = insertBits(Dest64, imm2 + 15, imm2, imm1);'
-    movkIop = InstObjParams("movk", "Movk", "RegImmImmOp", movkCode, [])
+    movkIop = InstObjParams("movk", "Movk", "RegImmImmMovkOp", movkCode, [])
     header_output += RegImmImmOpDeclare.subst(movkIop)
     decoder_output += RegImmImmOpConstructor.subst(movkIop)
     exec_output += BasicExecute.subst(movkIop)


### PR DESCRIPTION
- Add MOV (wide immediate) as alias for MOVZ;
- Add MOV (inverted wide immediate) as alias for MOVN;
- Insert LSL between immediate and shift for  MOVZ, MOVN and MOVK.