### PR TITLE
ARM64: Fix disassembly and dump for LDR (literal)

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -302,6 +302,7 @@ std::string
 MemoryLiteral64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    std::string label;
     int rd_width;
     uint32_t size = bits(machInst, 31, 30);
     if (size == 0)
@@ -310,7 +311,19 @@ MemoryLiteral64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
         rd_width = 64;
     printMnemonic(ss, "", false);
     printIntReg(ss, dest, rd_width);
-    ccprintf(ss, ", #%d", pc + imm);
+    if (symtab && symtab->findLabel(pc + imm, label))
+        ccprintf(ss, ", %s", label);
+    else
+        ccprintf(ss, ", #%d", imm);
     return ss.str();
+}
+
+bool
+MemoryLiteral64::markTarget(Addr pc, Addr &target, SymbolTable *symtab)
+{
+    target = pc + imm;
+    if (symtab)
+        symtab->insert_target(target);
+    return false;
 }
 }

--- a/src/arch/arm/insts/mem64.hh
+++ b/src/arch/arm/insts/mem64.hh
@@ -265,6 +265,8 @@ class MemoryLiteral64 : public Memory64
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+
+    bool markTarget(Addr pc, Addr &target, SymbolTable *symtab);
 };
 }
 

--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -80,7 +80,7 @@ RegRegRegImmOp64::generateDisassembly(
 std::string
 UnknownOp64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
-    return csprintf("%-10s (inst %#08x)", "unknown", encoding());
+    return csprintf("  .inst   %#010x", encoding());
 }
 
 Fault


### PR DESCRIPTION
- Fix disassembly format for unknown instruction.
- Fix disassembly dump of LDR (literal).