### PR TITLE
ARM64: Fix register width of Load/Store (register) disassembly

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -152,12 +152,60 @@ MemoryPostIndex64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
     return ss.str();
 }
 
+void
+MemoryReg64::printExtendOperand(bool firstOperand, std::ostream &os,
+                                IntRegIndex rm, ArmExtendType type,
+                                int64_t shiftAmt, int rm_width) const
+{
+    if (!firstOperand)
+        ccprintf(os, ", ");
+    printIntReg(os, rm, rm_width);
+    if (type == UXTX && shiftAmt == 0)
+        return;
+    switch (type) {
+      case UXTB: ccprintf(os, ", UXTB");
+        break;
+      case UXTH: ccprintf(os, ", UXTH");
+        break;
+      case UXTW: ccprintf(os, ", UXTW");
+        break;
+      case UXTX: ccprintf(os, ", LSL");
+        break;
+      case SXTB: ccprintf(os, ", SXTB");
+        break;
+      case SXTH: ccprintf(os, ", SXTH");
+        break;
+      case SXTW: ccprintf(os, ", SXTW");
+        break;
+      case SXTX: ccprintf(os, ", SXTX");
+        break;
+    }
+    if (type == UXTX || shiftAmt)
+        ccprintf(os, " #%d", shiftAmt);
+}
+
 std::string
 MemoryReg64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
-    startDisassembly(ss);
-    printExtendOperand(false, ss, offset, type, shiftAmt);
+    int rd_width;
+    int rm_width;
+    uint32_t size = bits(machInst, 31, 30);
+    uint32_t opc = bits(machInst, 23, 22);
+    uint32_t option = bits(machInst, 15, 13);
+    if (size == 0x3 || opc == 0x2)
+        rd_width = 64;
+    else
+        rd_width = 32;
+    if (option & 0x1)
+       rm_width = 64;
+    else
+       rm_width = 32;
+    printMnemonic(ss, "", false);
+    printIntReg(ss, dest, rd_width);
+    ccprintf(ss, ", [");
+    printIntReg(ss, base, 64);
+    printExtendOperand(false, ss, offset, type, shiftAmt, rm_width);
     ccprintf(ss, "]");
     return ss.str();
 }

--- a/src/arch/arm/insts/mem64.hh
+++ b/src/arch/arm/insts/mem64.hh
@@ -218,6 +218,10 @@ class MemoryReg64 : public Memory64
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+
+    void printExtendOperand(bool firstOperand, std::ostream &os,
+                            IntRegIndex rm, ArmExtendType type,
+                            int64_t shiftAmt, int rm_width) const;
 };
 
 class MemoryRaw64 : public Memory64


### PR DESCRIPTION
The width of Rd and Rm in Load/Store (register) shifted or extended
instructions could be 32 or 64 bits, depending on the size, opc and
option of each instruction. While the origin GEM5 always gives 64 bits
Rd and Rm in disassembly. This patch fixes the problem.

Change-Id: I061eae52adfd9a6fe95acd83a9e3d4e3ae3e80c7
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>