### PR TITLE
ARM64: Fix register width for disassembly of normal memory access ins…

### DIFF
--- a/src/arch/arm/insts/mem64.hh
+++ b/src/arch/arm/insts/mem64.hh
@@ -123,6 +123,7 @@ class Memory64 : public MightBeMicro64
     }
 
     void startDisassembly(std::ostream &os) const;
+    void startDisassembly(std::ostream &os, int rd_width) const;
 
     unsigned memAccessFlags;
 
@@ -218,6 +219,10 @@ class MemoryReg64 : public Memory64
 
     std::string generateDisassembly(
             Addr pc, const SymbolTable *symtab) const override;
+
+    void printExtendOperand(bool firstOperand, std::ostream &os,
+                            IntRegIndex rm, ArmExtendType type,
+                            int64_t shiftAmt, int rm_width) const;
 };
 
 class MemoryRaw64 : public Memory64


### PR DESCRIPTION
…tructions

For the normal memory access instructions, the width of Rd and Rm could be 32
or 64 bits, depending on the size, opc and option of each instruction, while
the base register is always 64 bit width. The origin GEM5 does not give a
correct disassembly result. This patch fixes the problem.

The instructions affected inlucde:
- Load/Store(immediate)
- Load/Store(pre-index)
- Load/Store(post-index)
- Load/Store(register)
- PRFM (register)
- LDR(literal)
- LDRSW(literal)
- PRFM (immediate)
- PRFM (literal)

Change-Id: Ie6f58a29712a91d0d9b4923b52a3ab84dddf4f2d
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>