### PR TITLE
ARM64: Fix register width of disassembly for Load/Store (exclusive or…

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -102,12 +102,14 @@ std::string
 MemoryDImm64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    uint32_t size = bits(machInst, 31, 30);
+    int rd_width = (size == 0x3) ? 64 : 32;
     printMnemonic(ss, "", false);
-    printIntReg(ss, dest);
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", ");
-    printIntReg(ss, dest2);
+    printIntReg(ss, dest2, rd_width);
     ccprintf(ss, ", [");
-    printIntReg(ss, base);
+    printIntReg(ss, base, 64);
     if (imm)
         ccprintf(ss, ", #%d", imm);
     ccprintf(ss, "]");
@@ -118,14 +120,18 @@ std::string
 MemoryDImmEx64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    uint32_t size = bits(machInst, 31, 30);
+    int rd_width = (size == 0x3) ? 64 : 32;
     printMnemonic(ss, "", false);
-    printIntReg(ss, result);
+    if (result != INTREG_X31) {
+        printIntReg(ss, result, 32);
+        ccprintf(ss, ", ");
+    }
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", ");
-    printIntReg(ss, dest);
-    ccprintf(ss, ", ");
-    printIntReg(ss, dest2);
+    printIntReg(ss, dest2, rd_width);
     ccprintf(ss, ", [");
-    printIntReg(ss, base);
+    printIntReg(ss, base, 64);
     if (imm)
         ccprintf(ss, ", #%d", imm);
     ccprintf(ss, "]");
@@ -166,7 +172,12 @@ std::string
 MemoryRaw64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
-    startDisassembly(ss);
+    uint32_t size = bits(machInst, 31, 30);
+    int rd_width = (size == 0x3) ? 64 : 32;
+    printMnemonic(ss, "", false);
+    printIntReg(ss, dest, rd_width);
+    ccprintf(ss, ", [");
+    printIntReg(ss, base, 64);
     ccprintf(ss, "]");
     return ss.str();
 }
@@ -175,12 +186,16 @@ std::string
 MemoryEx64::generateDisassembly(Addr pc, const SymbolTable *symtab) const
 {
     std::stringstream ss;
+    uint32_t size = bits(machInst, 31, 30);
+    int rd_width = (size == 0x3) ? 64 : 32;
     printMnemonic(ss, "", false);
-    printIntReg(ss, dest);
-    ccprintf(ss, ", ");
-    printIntReg(ss, result);
+    if (result != INTREG_X31) {
+        printIntReg(ss, result, 32);
+        ccprintf(ss, ", ");
+    }
+    printIntReg(ss, dest, rd_width);
     ccprintf(ss, ", [");
-    printIntReg(ss, base);
+    printIntReg(ss, base, 64);
     ccprintf(ss, "]");
     return ss.str();
 }


### PR DESCRIPTION
… not)

For some Load/Store instructions including:
- Load-Exclusive/Store-Exclusive instructions
- Non-exclusive Load-Acquire and Store-Release instructions
- Exclusive Load-Acquire and Store-Release instructions

the width of Rd could be 32 or 64 bits, depending on bit31:30 of the machine
code, the width of Rs is always 32 bits, and the width of Rn (base register)
is always 64 bits. The origin GEM5 does not give the correct disassembly.
This patch fixes the problem.

Change-Id: I4f7f7926127a6df8b85e0f695978b908a094fd05
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>