### PR TITLE
Trace: Save data information for atomic memory read

### DIFF
--- a/src/arch/generic/memhelpers.hh
+++ b/src/arch/generic/memhelpers.hh
@@ -81,8 +81,10 @@ readMemAtomic(XC *xc, Trace::InstRecord *traceData, Addr addr, MemT &mem,
     Fault fault = xc->readMem(addr, (uint8_t *)&mem, sizeof(MemT), flags);
     if (fault == NoFault) {
         mem = TheISA::gtoh(mem);
-        if (traceData)
+        if (traceData) {
             traceData->setData(mem);
+            traceData->setMemData((uint8_t *)&mem);
+        }
     }
     return fault;
 }

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -989,19 +989,23 @@ again:
 }
 
 bool
-BaseCPU::markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value)
+BaseCPU::markAccessed(OpClass opcls, Addr addr, Addr size, uint8_t *data)
 {
     int i;
 
+    if (data == NULL)
+        return false;
+#if 0
     // TODO: Try to skip stack accesses at an early stage
     if (size > 8) {
         std::cout << "WARN: Invalid access size ";
         std::cout << std::dec << size << "." << std::endl;
         size = 8;
     }
+#endif
     for (i = 0; i < size; i++) {
         Addr byteAddr = addr + i;
-        uint8_t byteData = (uint8_t)(value >> (i * 8));
+        uint8_t byteData = data[i];
 
         if (!find_mem_data(byteAddr, reads) &&
             !find_mem_data(byteAddr, writes)) {

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -236,7 +236,7 @@ class BaseCPU : public ClockedObject
     bool markStarted(Addr address);
     bool markExecuted(Addr address);
     bool markBranched(Addr address);
-    bool markAccessed(OpClass opcls, Addr addr, Addr size, uint64_t value);
+    bool markAccessed(OpClass opcls, Addr addr, Addr size, uint8_t *data);
     bool find_mem_data(Addr addr, std::list<MemData> &data_array);
     void insert_mem_data(Addr addr, uint8_t value,
                          std::list<MemData> &data_array);

--- a/src/cpu/exetrace.cc
+++ b/src/cpu/exetrace.cc
@@ -76,7 +76,7 @@ Trace::ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
     OpClass opcls = inst->opClass();
 
     if (opcls == MemReadOp || opcls == MemWriteOp) {
-        cpu->markAccessed(opcls, addr, size, data.as_int);
+        cpu->markAccessed(opcls, addr, size, memData);
     }
 
     if (!Debug::ExecUser || !Debug::ExecKernel) {

--- a/src/sim/insttracer.hh
+++ b/src/sim/insttracer.hh
@@ -83,6 +83,8 @@ class InstRecord
     Addr addr; ///< The address that was accessed
     Addr size; ///< The size of the memory request
     unsigned flags; ///< The flags that were assigned to the request.
+    static const int sizeMax = 16;
+    uint8_t memData[sizeMax];
 
     /** @} */
 
@@ -211,6 +213,13 @@ class InstRecord
         data.as_pred = new ::VecPredRegContainer<
             TheISA::VecPredRegSizeBits, TheISA::VecPredRegHasPackedRepr>(d);
         data_status = DataVecPred;
+    }
+
+    void setMemData(uint8_t *data)
+    {
+        if (data == NULL || size > sizeMax)
+            return;
+        memcpy(memData, data, size);
     }
 
     void setFetchSeq(InstSeqNum seq)


### PR DESCRIPTION
Add the function of saving data as byte array for atomic memory read. Current
max data size is 16 bytes (two 64-bit doublewords) to support LDP instruction.
It is easy to extended to support vector Load in the future.

Change-Id: If314805de07fb6b61f7820b0aac9fbf2e29c60f0
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>