### PR TITLE
NoncachingSimpleCPU: Make checkpoint with integer registers

### DIFF
--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -709,6 +709,12 @@ namespace ArmISA
 
         void startup(ThreadContext *tc);
 
+        // Dump register context
+        void dumpGenRegStore(BaseCPU *cpu, ThreadContext *tc);
+        void dumpGenRegLoad(BaseCPU *cpu, ThreadContext *tc);
+        void dumpMiscRegStore(BaseCPU *cpu, ThreadContext *tc);
+        void dumpMiscRegLoad(BaseCPU *cpu, ThreadContext *tc);
+        void dumpContextRegsEarly(BaseCPU *cpu, ThreadContext *tc);
         // Dump contexts of a sliced call
         void dumpCallContexts(BaseCPU *cpu, ThreadContext *tc,
                               Addr addr, Addr size, uint64_t value);

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -911,6 +911,7 @@ BaseCPU::markStarted(Addr address)
 {
     if (!_simpointStarted) {
         simpoint_entry = address;
+        dumpSimulatedRegisters();
         _simpointStarted = true;
     }
 

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -240,6 +240,7 @@ class BaseCPU : public ClockedObject
     bool find_mem_data(Addr addr, std::list<MemData> &data_array);
     void insert_mem_data(Addr addr, uint8_t value,
                          std::list<MemData> &data_array);
+    virtual void dumpSimulatedRegisters() {};
     virtual void dumpSimulatedSymbols() {};
     virtual void dumpSimulatedMemories() {};
 

--- a/src/cpu/simple/noncaching.hh
+++ b/src/cpu/simple/noncaching.hh
@@ -55,6 +55,7 @@ class NonCachingSimpleCPU : public AtomicSimpleCPU
     void verifyMemoryMode() const override;
 
     void dumpSimulatedSymbols();
+    void dumpSimulatedRegisters();
     void dumpSimulatedContexts();
 
   protected:


### PR DESCRIPTION
- Dump integer registers, including X0 to X31, into a read-only data section,
  and restore X0 to X28 (No X29 to X31) at the begin of SimPoint entry.
- Dump NZCV flags and restore, similar with above integer registers.
- Dump an infinite loop as exit(), the successeor of main().
- Add comments into SimPoint slice.
- Fix bug in dump of symbols for branch target.

Change-Id: I414b02bc186d3b150fe8be3b036f180819b0987c
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>