### PR TITLE
Provide a basic full system support for riscv

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -52,6 +52,7 @@ os_types = { 'alpha' : [ 'linux' ],
              'mips'  : [ 'linux' ],
              'sparc' : [ 'linux' ],
              'x86'   : [ 'linux' ],
+             'riscv' : [ 'linux' ],
              'arm'   : [ 'linux',
                          'android-gingerbread',
                          'android-ics',
@@ -432,6 +433,25 @@ def makeLinuxMipsSystem(mem_mode, mdesc=None, cmdline=None):
     if not cmdline:
         cmdline = 'root=/dev/hda1 console=ttyS0'
     self.boot_osflags = fillInCmdline(mdesc, cmdline)
+
+    self.system_port = self.membus.slave
+
+    return self
+
+def makeRiscvSystem(mem_mode, mdesc=None, cmdline=None):
+    self = BareMetalRiscvSystem()
+    if not mdesc:
+        # generic system
+        mdesc = SysConfig()
+
+    self.membus = MemBus()
+    self.mem_mode = mem_mode
+    self.mem_ranges = [AddrRange('4GB')]
+
+    #self.iobus = IOXBar()
+    #self.bridge = Bridge(delay='50ns')
+    #self.bridge.master = self.iobus.slave
+    #self.bridge.slave = self.membus.master
 
     self.system_port = self.membus.slave
 

--- a/configs/example/fs.py
+++ b/configs/example/fs.py
@@ -102,6 +102,8 @@ def build_test_system(np):
                                  security=options.enable_security_extensions)
         if options.enable_context_switch_stats_dump:
             test_sys.enable_context_switch_stats_dump = True
+    elif buildEnv['TARGET_ISA'] == "riscv":
+        test_sys = makeRiscvSystem(test_mem_mode, bm[0], cmdline=cmdline)
     else:
         fatal("Incapable of building %s full system!", buildEnv['TARGET_ISA'])
 
@@ -126,8 +128,8 @@ def build_test_system(np):
     if options.kernel is not None:
         test_sys.kernel = binary(options.kernel)
     else:
-        print("Error: a kernel must be provided to run in full system mode")
-        sys.exit(1)
+        print("Warn: a kernel should be provided to run in full system mode")
+        #sys.exit(1)
 
     if options.script is not None:
         test_sys.readfile = options.script
@@ -186,8 +188,10 @@ def build_test_system(np):
             test_sys.iocache = IOCache(addr_ranges = test_sys.mem_ranges)
             test_sys.iocache.cpu_side = test_sys.iobus.master
             test_sys.iocache.mem_side = test_sys.membus.slave
-        elif not options.external_memory_system:
-            test_sys.iobridge = Bridge(delay='50ns', ranges = test_sys.mem_ranges)
+        elif not options.external_memory_system and \
+                not buildEnv['TARGET_ISA'] == "riscv":
+            test_sys.iobridge = Bridge(delay='50ns', \
+                    ranges = test_sys.mem_ranges)
             test_sys.iobridge.slave = test_sys.iobus.master
             test_sys.iobridge.master = test_sys.membus.slave
 

--- a/src/arch/riscv/RiscvSystem.py
+++ b/src/arch/riscv/RiscvSystem.py
@@ -45,6 +45,7 @@ class RiscvSystem(System):
 class BareMetalRiscvSystem(RiscvSystem):
     type = 'BareMetalRiscvSystem'
     cxx_header = 'arch/riscv/bare_metal/system.hh'
-    bootloader = Param.String("File, that contains the bootloader code")
+    bootloader = Param.String('sdfirm_riscv64', \
+            "File, that contains the bootloader code")
 
     bare_metal = True


### PR DESCRIPTION
Set up a basic riscv full system. There are two known issues:

1. Setup for NoncoherentXBar is ignored to avoid the relevant error
2. Designation of bootloader for riscv is hardcoded

Change-Id: I608b81867c48c6ab2d1e4a6b728742da1c73b5c9
Signed-off-by: Ge Song <songgebird@gmail.com>