### PR TITLE
ARM64: Support to dumping heap memory pages in SimPoint slice

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -2371,6 +2371,8 @@ ISA::dumpStackStore(BaseCPU *cpu, ThreadContext *tc,
         }
         fp_idx_queue.push(i);
         fpVal = readMem(cpu, tc, (Addr)fp, __readMem);
+                if ((fpVal & 0xFFFFFFFFFFFFFFF0) == 0)
+                        break;
         ss.push(fpVal);
         i += 8;
         std::cout << "FP:";
@@ -2446,6 +2448,135 @@ ISA::dumpContextRegsLate(BaseCPU *cpu, ThreadContext *tc)
 }
 
 void
+ISA::dumpMemPagePrefix(BaseCPU *cpu, int page_cnt)
+{
+    cpu->simpoint_asm << "/*" << std::endl;
+    cpu->simpoint_asm << " * Section of memory pages." << std::endl;
+    cpu->simpoint_asm << " *   page count = " << page_cnt << std::endl;
+    cpu->simpoint_asm << " */" << std::endl;
+    cpu->simpoint_asm << ".section .SIMPOINT_MEM_PAGES" << std::endl;
+    cpu->simpoint_asm << "/* Memory page begin @ 0x0000 */" << std::endl;
+    cpu->simpoint_asm << ".balign 0x1000" << std::endl;
+    cpu->simpoint_asm << "simpoint_mem_page_0x0000:" << std::endl;
+    cpu->simpoint_asm << ".rept 0x1000" << std::endl;
+    cpu->simpoint_asm << "   .byte 0x00" << std::endl;
+    cpu->simpoint_asm << ".endr"<< std::endl;
+    cpu->simpoint_asm << std::dec;
+}
+
+void
+ISA::dumpMemPageBegin(BaseCPU *cpu, Addr addr)
+{
+    cpu->simpoint_asm << std::hex;
+    cpu->simpoint_asm << "/* Memory page begin @ 0x" << addr << " */" \
+                      << std::endl;
+    cpu->simpoint_asm << ".balign 0x1000" << std::endl;
+    cpu->simpoint_asm << "simpoint_mem_page_0x" << addr << ":" << std::endl;
+    cpu->simpoint_asm << std::dec;
+}
+
+void
+ISA::dumpMemPageEnd(BaseCPU *cpu, Addr addr)
+{
+    cpu->simpoint_asm << std::hex;
+    cpu->simpoint_asm << "/* Memory page end @ 0x" << addr << " */" \
+                      << std::endl;
+    cpu->simpoint_asm << std::dec;
+    cpu->simpoint_asm << std::endl;
+}
+
+void
+ISA::dumpMemZeroBytes(BaseCPU *cpu, Addr size)
+{
+    cpu->simpoint_asm << std::hex;
+    cpu->simpoint_asm << ".rept 0x" << size << std::endl;
+    cpu->simpoint_asm << "   .byte 0x00" << std::endl;
+    cpu->simpoint_asm << ".endr"<< std::endl;
+    cpu->simpoint_asm << std::dec;
+}
+
+void
+ISA::dumpMemOneByte(BaseCPU *cpu, uint8_t data)
+{
+    cpu->simpoint_asm << std::hex;
+    cpu->simpoint_asm << "   .byte 0x" << (short)data << std::endl;
+    cpu->simpoint_asm << std::dec;
+}
+
+void
+ISA::dumpPteGenBegin(BaseCPU *cpu, int page_cnt)
+{
+    cpu->simpoint_asm << "/*" << std::endl;
+    cpu->simpoint_asm << " * Generate PTE for memory pages." << std::endl;
+    cpu->simpoint_asm << " *   page count = " << page_cnt << std::endl;
+    cpu->simpoint_asm << " *" << std::endl;
+    cpu->simpoint_asm << " * Note:" << std::endl;
+    cpu->simpoint_asm << " *   The normal return i.e. a ret instruction is NOT"
+                      << " used here." << std::endl;
+    cpu->simpoint_asm << " *   Because we want to reserve all registers except"
+                      << " theses used in the two\n"
+                      << " *   macros create_pgd_entry and create_block_map."
+                      << std::endl;
+    cpu->simpoint_asm << " */" << std::endl;
+    cpu->simpoint_asm << std::endl;
+    cpu->simpoint_asm << "#include <target/paging.h>" << std::endl;
+    cpu->simpoint_asm << std::endl;
+    cpu->simpoint_asm << ".global simpoint_heap_map_entry" << std::endl;
+    cpu->simpoint_asm << ".section .text" << std::endl;
+    cpu->simpoint_asm << ".balign 4" << std::endl;
+    cpu->simpoint_asm << "simpoint_heap_map_entry:" << std::endl;
+    cpu->simpoint_asm << std::endl;
+}
+
+void
+ISA::dumpPteGenEnd(BaseCPU *cpu)
+{
+    cpu->simpoint_asm << "   b simpoint_heap_map_exit" << std::endl;
+    cpu->simpoint_asm << std::endl;
+}
+
+void
+ISA::dumpPteGen(BaseCPU *cpu, Addr virt_addr, Addr phys_offset)
+{
+    cpu->simpoint_asm << std::hex;
+        cpu->simpoint_asm << "   mov	x0, x26" << std::endl;
+        cpu->simpoint_asm << "   ldr	x5, =0x" << virt_addr << std::endl;
+        cpu->simpoint_asm << "   create_pgd_entry x0, x5, x3, x6" << std::endl;
+        cpu->simpoint_asm << "   add	x6, x5, #PAGE_SIZE" << std::endl;
+        cpu->simpoint_asm << "   ldr	x3, =(simpoint_heap_start+0x" \
+                                          << phys_offset << ")" << std::endl;
+        cpu->simpoint_asm << "   create_block_map x0, x7, x3, x5, x6" \
+                                          << std::endl;
+    cpu->simpoint_asm << std::dec;
+    cpu->simpoint_asm << std::endl;
+}
+
+void
+ISA::dumpMemBegin(BaseCPU *cpu)
+{
+    cpu->simpoint_asm << ".section .text" << std::endl;
+    cpu->simpoint_asm << ".balign 4" << std::endl;
+    cpu->simpoint_asm << "simpoint_dump_memory_entry:" << std::endl;
+}
+
+void
+ISA::dumpMemU64(BaseCPU *cpu, Addr addr, uint64_t value)
+{
+    cpu->simpoint_asm << std::hex;
+    cpu->simpoint_asm << "   ldr    x5, =0x" << addr << std::endl;
+    cpu->simpoint_asm << "   ldr    x6, =0x" << value << std::endl;
+    cpu->simpoint_asm << "   str    x6, [x5]" << std::endl;
+    cpu->simpoint_asm << std::dec;
+}
+
+void
+ISA::dumpMemEnd(BaseCPU *cpu)
+{
+    cpu->simpoint_asm << "   b simpoint_dump_memory_exit" << std::endl;
+    cpu->simpoint_asm << std::endl;
+}
+
+void
 ISA::dumpSimpointInit(BaseCPU *cpu)
 {
     cpu->simpoint_asm << "/* Begin of SimPoint */" << std::endl;
@@ -2461,6 +2592,10 @@ ISA::dumpSimpointInit(BaseCPU *cpu)
     cpu->simpoint_asm << "   // XXX Run b NegXSRegCc in gdb." << std::endl;
     cpu->simpoint_asm << "   NEGS W0, W1, ASR #4" << std::endl;
     cpu->simpoint_asm << std::endl;
+
+    cpu->simpoint_asm << "   b simpoint_dump_memory_entry" << std::endl;
+    cpu->simpoint_asm << "simpoint_dump_memory_exit:" << std::endl;
+    cpu->simpoint_asm << std::endl;
 }
 
 void
@@ -2471,6 +2606,7 @@ ISA::dumpSimpointExit(BaseCPU *cpu)
     cpu->simpoint_asm << "exit:" << std::endl;
     cpu->simpoint_asm << "  nop" << std::endl;
     cpu->simpoint_asm << "  b     simpoint_exit" << std::endl;
+    cpu->simpoint_asm << std::endl;
 }
 
 void

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -757,6 +757,17 @@ namespace ArmISA
         void dumpStackLoad(BaseCPU *cpu, ThreadContext *tc);
         void dumpContextRegsEarly(BaseCPU *cpu, ThreadContext *tc);
         void dumpContextRegsLate(BaseCPU *cpu, ThreadContext *tc);
+        void dumpMemPagePrefix(BaseCPU *cpu, int page_cnt);
+        void dumpMemPageBegin(BaseCPU *cpu, Addr addr);
+        void dumpMemPageEnd(BaseCPU *cpu, Addr addr);
+        void dumpMemZeroBytes(BaseCPU *cpu, Addr size);
+        void dumpMemOneByte(BaseCPU *cpu, uint8_t data);
+        void dumpPteGenBegin(BaseCPU *cpu, int page_cnt);
+        void dumpPteGen(BaseCPU *cpu, Addr virt_addr, Addr phys_offset);
+        void dumpPteGenEnd(BaseCPU *cpu);
+        void dumpMemBegin(BaseCPU *cpu);
+        void dumpMemU64(BaseCPU *cpu, Addr addr, uint64_t value);
+        void dumpMemEnd(BaseCPU *cpu);
         // Dump init of simpoint
         void dumpSimpointInit(BaseCPU *cpu);
         // Dump exit of simpoint

--- a/src/base/mem_page.hh
+++ b/src/base/mem_page.hh
@@ -1,0 +1,31 @@
+#ifndef __CPU_MEM_PAGE_HH__
+#define __CPU_MEM_PAGE_HH__
+
+#include <memory>
+#include <set>
+
+#include "arch/types.hh"
+#include "base/types.hh"
+
+#define MEM_PAGE_SHIFT (12)
+#define MEM_PAGE_SIZE (((Addr)1) << MEM_PAGE_SHIFT)
+#define MEM_PAGE_MASK (~(MEM_PAGE_SIZE-1))
+
+class MemPage
+{
+  public:
+    uint8_t data[MEM_PAGE_SIZE];
+    Addr addr;
+
+    MemPage(Addr _addr) : addr(_addr)
+    {
+        memset(data, 0, sizeof(data));
+    }
+
+    bool operator< (const MemPage &page) const
+    {
+        return (this->addr < page.addr);
+    }
+};
+
+#endif /* __CPU_MEM_PAGE_HH__ */

--- a/src/cpu/simple/noncaching.hh
+++ b/src/cpu/simple/noncaching.hh
@@ -56,6 +56,7 @@ class NonCachingSimpleCPU : public AtomicSimpleCPU
 
     void dumpSimulatedSymbols();
     void dumpSimulatedRegisters();
+    void dumpSimulatedPages();
     void dumpSimulatedContexts();
 
   protected:


### PR DESCRIPTION
Add functions to dump heap memory pages and create PTEs, and dump heap memory pages in SimPoint slice.