### PR TITLE
RISCV: Fix immediate width for disassembling integer shift immediate …

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -413,9 +413,6 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: addi({{
                     Rd_sd = Rs1_sd + imm;
                 }});
-                0x1: slli({{
-                    Rd = Rs1 << SHAMT6;
-                }});
                 0x2: slti({{
                     Rd = (Rs1_sd < imm) ? 1 : 0;
                 }});
@@ -425,6 +422,17 @@ decode QUADRANT default Unknown::unknown() {
                 0x4: xori({{
                     Rd = Rs1 ^ imm;
                 }}, uint64_t);
+                0x6: ori({{
+                    Rd = Rs1 | imm;
+                }}, uint64_t);
+                0x7: andi({{
+                    Rd = Rs1 & imm;
+                }}, uint64_t);
+            }
+            format ISOp {
+                0x1: slli({{
+                    Rd = Rs1 << SHAMT6;
+                }});
                 0x5: decode SRTYPE {
                     0x0: srli({{
                         Rd = Rs1 >> SHAMT6;
@@ -433,12 +441,6 @@ decode QUADRANT default Unknown::unknown() {
                         Rd_sd = Rs1_sd >> SHAMT6;
                     }});
                 }
-                0x6: ori({{
-                    Rd = Rs1 | imm;
-                }}, uint64_t);
-                0x7: andi({{
-                    Rd = Rs1 & imm;
-                }}, uint64_t);
             }
         }
 
@@ -451,6 +453,8 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: addiw({{
                     Rd_sd = Rs1_sw + imm;
                 }}, int32_t);
+            }
+            format ISOp {
                 0x1: slliw({{
                     Rd_sd = Rs1_sw << SHAMT5;
                 }});

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -309,6 +309,17 @@ def format IOp(code, imm_type='int64_t', *opt_flags) {{
     exec_output = ImmExecute.subst(iop)
 }};
 
+def format ISOp(code, imm_type='int64_t', *opt_flags) {{
+    regs = ['_destRegIdx[0]','_srcRegIdx[0]']
+    iop = InstObjParams(name, Name, 'ImmOp<%s>' % imm_type,
+        {'code': code, 'imm_code': 'imm = sext<12>(IMM12&0x03F);',
+         'regs': ','.join(regs)}, opt_flags)
+    header_output = ImmDeclare.subst(iop)
+    decoder_output = ImmConstructor.subst(iop)
+    decode_block = BasicDecode.subst(iop)
+    exec_output = ImmExecute.subst(iop)
+}};
+
 def format BOp(code, *opt_flags) {{
     imm_code = """
                 imm = BIMM12BITS4TO1 << 1  |


### PR DESCRIPTION
…instructions

The "shamt" in integer shift immediate instructions is an immediate encoded in
bits[25:20]. While the original Gem5 uses bits[31:20]. This patch fixes the
problem.

The instructions affected include:
- Shift Left Logical Immediate, slli
- Shift Right Logical Immediate, srli
- Shift Right Arithmetic Immediate, srai
- Shift Left Logical Word Immediate, slliw
- Shift Right Logical Word Immediate, srliw
- Shift Right Arithmetic Word Immediate, sraiw

Change-Id: I3c03eebffda3857f51bafa627837979f73713b74
Signed-off-by: Ian Jiang <ianjiang.ict@gmail.com>