### PR TITLE
RISCV: Fix disassembling immediate for some integer instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -413,9 +413,6 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: addi({{
                     Rd_sd = Rs1_sd + imm;
                 }});
-                0x1: slli({{
-                    Rd = Rs1 << SHAMT6;
-                }});
                 0x2: slti({{
                     Rd = (Rs1_sd < imm) ? 1 : 0;
                 }});
@@ -425,6 +422,17 @@ decode QUADRANT default Unknown::unknown() {
                 0x4: xori({{
                     Rd = Rs1 ^ imm;
                 }}, uint64_t);
+                0x6: ori({{
+                    Rd = Rs1 | imm;
+                }}, uint64_t);
+                0x7: andi({{
+                    Rd = Rs1 & imm;
+                }}, uint64_t);
+            }
+            format ISOp {
+                0x1: slli({{
+                    Rd = Rs1 << SHAMT6;
+                }});
                 0x5: decode SRTYPE {
                     0x0: srli({{
                         Rd = Rs1 >> SHAMT6;
@@ -433,12 +441,6 @@ decode QUADRANT default Unknown::unknown() {
                         Rd_sd = Rs1_sd >> SHAMT6;
                     }});
                 }
-                0x6: ori({{
-                    Rd = Rs1 | imm;
-                }}, uint64_t);
-                0x7: andi({{
-                    Rd = Rs1 & imm;
-                }}, uint64_t);
             }
         }
 
@@ -451,6 +453,8 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: addiw({{
                     Rd_sd = Rs1_sw + imm;
                 }}, int32_t);
+            }
+            format ISOp {
                 0x1: slliw({{
                     Rd_sd = Rs1_sw << SHAMT5;
                 }});

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -309,6 +309,17 @@ def format IOp(code, imm_type='int64_t', *opt_flags) {{
     exec_output = ImmExecute.subst(iop)
 }};
 
+def format ISOp(code, imm_type='int64_t', *opt_flags) {{
+    regs = ['_destRegIdx[0]','_srcRegIdx[0]']
+    iop = InstObjParams(name, Name, 'ImmOp<%s>' % imm_type,
+        {'code': code, 'imm_code': 'imm = sext<12>(IMM12&0x03F);',
+         'regs': ','.join(regs)}, opt_flags)
+    header_output = ImmDeclare.subst(iop)
+    decoder_output = ImmConstructor.subst(iop)
+    decode_block = BasicDecode.subst(iop)
+    exec_output = ImmExecute.subst(iop)
+}};
+
 def format BOp(code, *opt_flags) {{
     imm_code = """
                 imm = BIMM12BITS4TO1 << 1  |

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -90,6 +90,38 @@ def template ImmExecute {{
     }
 }};
 
+def template ImmShiftExecute {{
+    Fault
+    %(class_name)s::execute(
+        ExecContext *xc, Trace::InstRecord *traceData) const
+    {
+        Fault fault = NoFault;
+
+        %(op_decl)s;
+        %(op_rd)s;
+        if (fault == NoFault) {
+            %(code)s;
+            if (fault == NoFault) {
+                %(op_wb)s;
+            }
+        }
+        return fault;
+    }
+
+    std::string
+    %(class_name)s::generateDisassembly(Addr pc,
+            const SymbolTable *symtab) const
+    {
+        std::vector<RegId> indices = {%(regs)s};
+        std::stringstream ss;
+        ss << mnemonic << ' ';
+        for (const RegId& idx: indices)
+            ss << registerName(idx) << ", ";
+        ss << (imm >> 12);
+        return ss.str();
+    }
+}};
+
 def template BranchDeclare {{
     //
     // Static instruction class for "%(mnemonic)s".
@@ -357,7 +389,7 @@ def format UOp(code, *opt_flags) {{
     header_output = ImmDeclare.subst(iop)
     decoder_output = ImmConstructor.subst(iop)
     decode_block = BasicDecode.subst(iop)
-    exec_output = ImmExecute.subst(iop)
+    exec_output = ImmShiftExecute.subst(iop)
 }};
 
 def format JOp(code, *opt_flags) {{


### PR DESCRIPTION
- Fix disassembling immediate for auipc and lui instructions.
- Fix immediate width in decoding integer shift immediate instructions.